### PR TITLE
fix #COMSLI-630 (https://jira.six-group.net/browse/COMSLI-630) Icon missaligned 

### DIFF
--- a/source/packages/ui-library/src/components/six-sidebar-item-group/six-sidebar-item-group.scss
+++ b/source/packages/ui-library/src/components/six-sidebar-item-group/six-sidebar-item-group.scss
@@ -17,10 +17,6 @@
   transform: translate(0px, -3px);
 }
 
-.six-sidebar-details__header {
-  display: flex;
-}
-
 .six-sidebar-details__header-icon {
   margin-right: 1em;
 }


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch for v2.x (or to a previous version branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [x] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Hallo SIX Web Component Design Team
Ich habe eine Frage bezüglich des <six-sidebar-item-group> tags.
Wenn man ein Icon hinzufügt ist es immer ein wenig unter dem Text also ein wenig versetzt.