### PR TITLE
truncate large text in six-select and add tooltips fixes #67

### DIFF
--- a/libraries/ui-library/src/components/six-select/six-select.scss
+++ b/libraries/ui-library/src/components/six-select/six-select.scss
@@ -24,7 +24,6 @@
   background-color: var(--six-input-background-color);
   border: solid var(--six-border-width) var(--six-input-border-color);
   vertical-align: middle;
-  overflow: hidden;
   transition: var(--six-transition-fast) color, var(--six-transition-fast) border, var(--six-transition-fast) box-shadow;
   cursor: pointer;
 
@@ -102,6 +101,10 @@
   @include hide-scrollbar;
   overflow-x: auto;
   overflow-y: hidden;
+  text-overflow: ellipsis;
+}
+
+.select__label--single {
   white-space: nowrap;
 }
 
@@ -133,7 +136,7 @@
 
 // Tags
 .select__tags {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   flex-wrap: wrap;
   justify-content: left;
@@ -186,9 +189,6 @@
 
     six-tag {
       padding-top: 2px;
-    }
-
-    six-tag:not(:last-of-type) {
       margin-right: var(--six-spacing-xx-small);
     }
   }
@@ -227,9 +227,6 @@
 
     six-tag {
       padding-top: 3px;
-    }
-
-    six-tag:not(:last-of-type) {
       margin-right: var(--six-spacing-xx-small);
     }
   }
@@ -268,9 +265,6 @@
 
     six-tag {
       padding-top: 4px;
-    }
-
-    six-tag:not(:last-of-type) {
       margin-right: var(--six-spacing-xx-small);
     }
   }

--- a/libraries/ui-library/src/components/six-select/six-select.tsx
+++ b/libraries/ui-library/src/components/six-select/six-select.tsx
@@ -266,7 +266,7 @@ export class SixSelect {
   }
 
   private getValueAsArray() {
-    const values = Array.isArray(this.value) ? this.value : [this.value];
+    const values = Array.isArray(this.value) ? this.value : this.value === '' ? [] : [this.value];
     // enforce that the values are converted to 'string' before the value is compared
     return values.map(String);
   }
@@ -587,7 +587,7 @@ export class SixSelect {
             onFocus={this.handleFocus}
             onKeyDown={this.handleKeyDown}
           >
-            <span class="select__label">
+            <span class={{ select__label: true, 'select__label--single': !this.displayTags.length }}>
               {this.displayTags.length > 0 ? (
                 <span part="tags" class="select__tags">
                   {this.displayTags}

--- a/libraries/ui-library/src/components/six-select/test/six-select.spec.tsx
+++ b/libraries/ui-library/src/components/six-select/test/six-select.spec.tsx
@@ -22,7 +22,7 @@ describe('six-select', () => {
               <div class="form-control__input">
                 <six-dropdown class="select select--empty select--medium select--placeholder-visible" closeonselect="" filterdebounce="300" part="base">
                   <div aria-describedby="select-help-text-1" aria-expanded="false" aria-haspopup="true" aria-labelledby="select-label-1" class="select__box" id="select-1" role="combobox" slot="trigger" tabindex="0">
-                    <span class="select__label"></span>
+                    <span class="select__label select__label--single"></span>
                     <span class="select__icon" part="icon">
                       <six-icon size="medium">expand_more</six-icon>
                     </span>
@@ -65,7 +65,7 @@ describe('six-select', () => {
               <div class="form-control__input">
                 <six-dropdown class="select select--empty select--medium select--placeholder-visible" closeonselect="" disablehideonenterandspace="" filterdebounce="300" part="base">
                   <div aria-describedby="select-help-text-2" aria-expanded="false" aria-haspopup="true" aria-labelledby="select-label-2" class="select__box select__box--autocomplete" id="select-2" role="combobox" slot="trigger" tabindex="0">
-                    <span class="select__label"></span>
+                    <span class="select__label select__label--single"></span>
                     <six-input aria-hidden="true" class="select__input" placeholder="" size="medium" tabindex="-1"></six-input>
                   </div>
                   <six-menu class="select__menu select__menu--hidden" part="menu" remove-box-shadow>

--- a/libraries/ui-library/src/components/six-tag/six-tag.scss
+++ b/libraries/ui-library/src/components/six-tag/six-tag.scss
@@ -2,6 +2,7 @@
 
 :host {
   display: inline-block;
+  overflow: hidden;
 }
 
 .tag {
@@ -13,6 +14,11 @@
   white-space: nowrap;
   user-select: none;
   cursor: default;
+}
+
+.tag__content {
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 .tag__clear::part(base) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch for v2.x (or to a previous version branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
If the text exceeds the width of the `six-menu-item`, it is truncated. Additionally, a tooltip is shown for selected items in a `six-select` when `multiple` is set to true.