### PR TITLE
feat: tooltip for truncated six-tag elements

### DIFF
--- a/docs/components/six-select.md
+++ b/docs/components/six-select.md
@@ -161,7 +161,7 @@ To allow multiple options to be selected, use the `multiple` attribute. It's a g
   <six-menu-divider></six-menu-divider>
   <six-menu-item value="option-4">Option 4</six-menu-item>
   <six-menu-item value="option-5">Option 5</six-menu-item>
-  <six-menu-item value="option-6">Option 6</six-menu-item>
+  <six-menu-item value="option-6">Option 6 (with tooltip due to long text)</six-menu-item>
 </six-select>
 ```
 
@@ -759,6 +759,7 @@ graph TD;
   six-select --> six-menu
   six-select --> six-error
   six-menu-item --> six-icon
+  six-tag --> six-tooltip
   six-tag --> six-icon-button
   six-icon-button --> six-icon
   six-dropdown --> six-menu-item

--- a/docs/components/six-tag.md
+++ b/docs/components/six-tag.md
@@ -76,6 +76,17 @@ Use the `clearable` attribute to add a clear button to the tag.
 ```
 
 
+### Tooltip
+
+A tooltip with the full text is shown if the content doesn't fit inside the tag.
+
+<docs-demo-six-tag-4></docs-demo-six-tag-4>
+
+```html
+<six-tag style="width: 100px">Tag with a long text</six-tag>
+```
+
+
 
 <!-- Auto Generated Below -->
 
@@ -121,11 +132,13 @@ Use the `clearable` attribute to add a clear button to the tag.
 
 ### Depends on
 
+- [six-tooltip](six-tooltip.html)
 - [six-icon-button](six-icon-button.html)
 
 ### Graph
 ```mermaid
 graph TD;
+  six-tag --> six-tooltip
   six-tag --> six-icon-button
   six-icon-button --> six-icon
   six-select --> six-tag

--- a/docs/components/six-tooltip.md
+++ b/docs/components/six-tooltip.md
@@ -290,11 +290,13 @@ Type: `Promise<void>`
 
 ### Used by
 
+ - [six-tag](six-tag.html)
  - [six-tile](six-tile.html)
 
 ### Graph
 ```mermaid
 graph TD;
+  six-tag --> six-tooltip
   six-tile --> six-tooltip
   style six-tooltip fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/docs/examples/docs-demo-six-select-9.vue
+++ b/docs/examples/docs-demo-six-select-9.vue
@@ -8,7 +8,7 @@
           <six-menu-divider></six-menu-divider>
           <six-menu-item value="option-4">Option 4</six-menu-item>
           <six-menu-item value="option-5">Option 5</six-menu-item>
-          <six-menu-item value="option-6">Option 6</six-menu-item>
+          <six-menu-item value="option-6">Option 6 (with tooltip due to long text)</six-menu-item>
         </six-select>
       
 </div>

--- a/docs/examples/docs-demo-six-tag-4.vue
+++ b/docs/examples/docs-demo-six-tag-4.vue
@@ -1,0 +1,16 @@
+<template>
+<div>
+
+        <six-tag style="width: 100px">Tag with a long text</six-tag>
+      
+</div>
+</template>
+<style>
+
+</style>
+<script>
+export default {
+  name: 'docs-demo-six-tag-4',
+  mounted() {  }
+}
+</script>

--- a/libraries/ui-library/src/components/six-select/index.html
+++ b/libraries/ui-library/src/components/six-select/index.html
@@ -131,7 +131,7 @@
           <six-menu-divider></six-menu-divider>
           <six-menu-item value="option-4">Option 4</six-menu-item>
           <six-menu-item value="option-5">Option 5</six-menu-item>
-          <six-menu-item value="option-6">Option 6</six-menu-item>
+          <six-menu-item value="option-6">Option 6 (with tooltip due to long text)</six-menu-item>
         </six-select>
       </section>
 

--- a/libraries/ui-library/src/components/six-select/readme.md
+++ b/libraries/ui-library/src/components/six-select/readme.md
@@ -108,6 +108,7 @@ graph TD;
   six-select --> six-menu
   six-select --> six-error
   six-menu-item --> six-icon
+  six-tag --> six-tooltip
   six-tag --> six-icon-button
   six-icon-button --> six-icon
   six-dropdown --> six-menu-item

--- a/libraries/ui-library/src/components/six-tag/index.html
+++ b/libraries/ui-library/src/components/six-tag/index.html
@@ -65,6 +65,12 @@
           }
         </style>
       </section>
+
+      <h3>Tooltip</h3>
+      <p>A tooltip with the full text is shown if the content doesn't fit inside the tag.</p>
+      <section>
+        <six-tag style="width: 100px">Tag with a long text</six-tag>
+      </section>
     </div>
   </body>
 </html>

--- a/libraries/ui-library/src/components/six-tag/readme.md
+++ b/libraries/ui-library/src/components/six-tag/readme.md
@@ -46,11 +46,13 @@
 
 ### Depends on
 
+- [six-tooltip](../six-tooltip)
 - [six-icon-button](../six-icon-button)
 
 ### Graph
 ```mermaid
 graph TD;
+  six-tag --> six-tooltip
   six-tag --> six-icon-button
   six-icon-button --> six-icon
   six-select --> six-tag

--- a/libraries/ui-library/src/components/six-tag/test/six-tag.spec.tsx
+++ b/libraries/ui-library/src/components/six-tag/test/six-tag.spec.tsx
@@ -2,18 +2,29 @@ import { newSpecPage } from '@stencil/core/testing';
 import { SixTag } from '../six-tag';
 
 describe('six-tag', () => {
+  beforeEach(async () => {
+    global.ResizeObserver = jest.fn().mockImplementation(() => ({
+      observe: jest.fn(),
+      unobserve: jest.fn(),
+      disconnect: jest.fn(),
+    }));
+  });
+
   it('renders', async () => {
     const page = await newSpecPage({
       components: [SixTag],
       html: `<six-tag size="small">label</six-tag>`,
     });
     expect(page.root).toEqualHtml(`
+
       <six-tag size="small" type="primary">
         <mock:shadow-root>
           <span class="tag tag--primary tag--small" part="base">
+          <six-tooltip>
             <span class="tag__content" part="content">
               <slot></slot>
             </span>
+            </six-tooltip>
           </span>
         </mock:shadow-root>
         label
@@ -30,9 +41,11 @@ describe('six-tag', () => {
       <six-tag clearable="" size="medium" type="primary">
         <mock:shadow-root>
           <span class="tag tag--clear tag--medium tag--primary" part="base">
+          <six-tooltip>
             <span class="tag__content" part="content">
               <slot></slot>
             </span>
+          </six-tooltip>
             <six-icon-button class="tag__clear" exportparts="base:clear-button" name="clear" size="xSmall"></six-icon-button>
           </span>
         </mock:shadow-root>

--- a/libraries/ui-library/src/components/six-tooltip/readme.md
+++ b/libraries/ui-library/src/components/six-tooltip/readme.md
@@ -85,11 +85,13 @@ Type: `Promise<void>`
 
 ### Used by
 
+ - [six-tag](../six-tag)
  - [six-tile](../six-tile)
 
 ### Graph
 ```mermaid
 graph TD;
+  six-tag --> six-tooltip
   six-tile --> six-tooltip
   style six-tooltip fill:#f9f,stroke:#333,stroke-width:4px
 ```

--- a/libraries/ui-library/src/components/six-tooltip/six-tooltip.scss
+++ b/libraries/ui-library/src/components/six-tooltip/six-tooltip.scss
@@ -22,7 +22,7 @@
 }
 
 .tooltip-positioner {
-  position: absolute;
+  position: fixed;
   z-index: var(--six-z-index-tooltip);
   pointer-events: none;
 }

--- a/libraries/ui-library/src/components/six-tooltip/six-tooltip.tsx
+++ b/libraries/ui-library/src/components/six-tooltip/six-tooltip.tsx
@@ -91,7 +91,7 @@ export class SixTooltip {
   componentDidLoad() {
     if (this.tooltipPositioner == null) return;
     this.target = this.getTarget();
-    this.popover = new Popover(this.target, this.tooltipPositioner);
+    this.popover = new Popover(this.target, this.tooltipPositioner, { strategy: 'fixed' });
     this.syncOptions();
 
     this.host.addEventListener('blur', this.handleBlur, true);


### PR DESCRIPTION
### Example
![image](https://github.com/six-group/six-webcomponents/assets/1475511/ac9e383e-5c1a-491a-b19e-d95f82afa037)
