### PR TITLE
Fix APP_INITIALIZER problem in ui-library-angular

### DIFF
--- a/libraries/ui-library-angular/src/lib/ui-library-angular.module.ts
+++ b/libraries/ui-library-angular/src/lib/ui-library-angular.module.ts
@@ -84,11 +84,9 @@ export class UiLibraryAngularModule {
       providers: [
         {
           provide: APP_INITIALIZER,
-          useFactory: () => {
-            return defineCustomElements();
-          },
+          useFactory: () => async () => defineCustomElements(),
+          multi: true,
         },
-
         { provide: ValidationMessagesService, useClass: customValidationMessagesService ?? ValidationMessagesService },
       ],
     };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/six-group/six-webcomponents/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `main` branch for v2.x (or to a previous version branch)
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

fixed problem where apps which relied on ui-library-angular were not able to use app_initializer, since ui-library-angular already provided an app_initializer which was not set to multi

