### PR TITLE
Bugfix for fixing issue 109 - changed path for favicon, since it was not properly loaded with…

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -16,7 +16,7 @@ const componentNavItems = components.map((component) => {
 export default defineConfig({
   ignoreDeadLinks: [/^https?:\/\/localhost/, './../wrappers/set-attributes'],
   appearance: false,
-  head: [['link', { rel: 'icon', href: '/favicon.ico' }]],
+  head: [['link', { rel: 'icon', href: 'favicon.ico' }]],
   title: 'Web Components',
   description: 'Component Library following the SIX Style Guide',
   base: '/six-webcomponents/',


### PR DESCRIPTION
… github pages

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/six-group/six-webcomponents/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [x] It's submitted to the `main` branch for v2.x (or to a previous version branch)
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:
- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**

On github pages the favicon was not properly loaded, this will hopefully fix it. I can not reproduce the issue locally, but at least when I remove the slash in the browser of the deployed docs, it correctly loads the favicon.
