### PR TITLE
added focus visible

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Experimental support for Vue
 - Updated the `six-item-picker` component to include tabindex attributes for better accessibility.
+- Added focus-visible to 'six-checkbox' component for better accessibility.
 
 ### Changed
 

--- a/libraries/ui-library/src/components/six-checkbox/six-checkbox.scss
+++ b/libraries/ui-library/src/components/six-checkbox/six-checkbox.scss
@@ -16,6 +16,13 @@
   cursor: pointer;
 }
 
+.checkbox--focused {
+  .checkbox__control {
+    outline: var(--six-focus-ring);
+    outline-offset: 0;
+  }
+}
+
 .checkbox__control {
   position: relative;
   display: inline-flex;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/six-group/six-webcomponents/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The checkbox component now includes a 'focus visible' feature, enhancing accessibility by providing a clear visual indicator for users.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] I have updated the documentation accordingly.
- [x] All tests are passing
- [ ] New/updated tests are included
- [x] I have updated the "upcoming" section inside _docs/changelog.md_ explaining the changes I contributed

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
![image](https://github.com/six-group/six-webcomponents/assets/129514033/daccf0a2-0a34-49e3-961a-17a5235e57eb)

![image](https://github.com/six-group/six-webcomponents/assets/129514033/b044e639-e1f0-49c3-b92f-def8be7f01e1)
