### PR TITLE
six-header: Toggle the app switcher when clicking on the app name

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Icon names are not selectable anymore
 - Slot of six-icon was not centered
 - Fixed problem where datepicker height is not adjusted when using hoist property
+- Clicking on the active app in six-header toggles the app switcher
 
 ## 4.0.4 - 2023-11-15
 

--- a/libraries/ui-library/src/components/six-header/six-header.scss
+++ b/libraries/ui-library/src/components/six-header/six-header.scss
@@ -56,6 +56,11 @@ $border-height: 0.25rem;
     }
   }
 
+  &__app-switcher-dropdown {
+    display: flex;
+    align-items: center;
+  }
+
   &__selected-app {
     cursor: pointer;
     font-size: 0.9rem;

--- a/libraries/ui-library/src/components/six-header/six-header.tsx
+++ b/libraries/ui-library/src/components/six-header/six-header.tsx
@@ -259,11 +259,13 @@ export class SixHeader {
           'six-header__app-switcher--open': this.isSectionSelected(Section.AppSwitcher),
         }}
       >
-        <a onClick={this.appNameClicked} class="six-header__selected-app">
-          {this.selectedApp}
-        </a>
         <six-dropdown distance={13} skidding={20} placement="bottom-end" ref={this.setupAppSwitcher}>
-          <six-icon-button name="apps" slot="trigger" />
+          <div slot="trigger" class="six-header__app-switcher-dropdown">
+            <a onClick={this.appNameClicked} class="six-header__selected-app">
+              {this.selectedApp}
+            </a>
+            <six-icon-button name="apps" />
+          </div>
           <slot name={Slot.AppSwitcher} />
         </six-dropdown>
       </section>

--- a/libraries/ui-library/src/components/six-header/test/six-header.spec.tsx
+++ b/libraries/ui-library/src/components/six-header/test/six-header.spec.tsx
@@ -127,9 +127,11 @@ describe('six-header', () => {
               <slot></slot>
             </section>
             <section class="six-header__app-switcher">
-                <a class="six-header__selected-app">Swiss Interbank Clearing</a>
                 <six-dropdown distance="13" placement="bottom-end" skidding="20">
-                  <six-icon-button name="apps" slot="trigger"></six-icon-button>
+                  <div class="six-header__app-switcher-dropdown" slot="trigger">
+                    <a class="six-header__selected-app">Swiss Interbank Clearing</a>
+                    <six-icon-button name="apps"></six-icon-button>
+                  </div>
                   <slot name="app-switcher-menu"></slot>
                </six-dropdown>
            </section>


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Fixes an issue where clicking the active app name in the six-header did not trigger the app switcher menu to open.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] I have updated the documentation accordingly.
- [x] All tests are passing
- [ ] New/updated tests are included
- [x] I have updated the "upcoming" section inside _docs/changelog.md_ explaining the changes I contributed
