### PR TITLE
feature #202 and fix #204

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added part to svg, so users are able to resize the six logo spinner
 - Added `matchTriggerWidth` property to `six-dropdown`.
 - Utility to display toast alerts in Angular and Vue.
+- Added `uploading`property to `six-file-upload`.
 
 ### Changed
 
@@ -51,9 +52,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Clicking on the active app in six-header toggles the app switcher
 - Fixed six-details to not change text color on hover
 - Box Shadow for toast alerts
-- six-select filter not working when items passed via options property
-- Disabling a SIX web components input element in an Angular form correctly hides any error messages
-  on the input
 
 ## 4.0.4 - 2023-11-15
 

--- a/docs/components/six-file-upload.md
+++ b/docs/components/six-file-upload.md
@@ -116,20 +116,30 @@ You can define a custom label via the `label` attribute
 ```
 
 
+### Uploading
+
+<docs-demo-six-file-upload-5></docs-demo-six-file-upload-5>
+
+```html
+<six-file-upload uploading></six-file-upload>
+```
+
+
 
 <!-- Auto Generated Below -->
 
 
 ## Properties
 
-| Property      | Attribute       | Description                                  | Type                  | Default     |
-| ------------- | --------------- | -------------------------------------------- | --------------------- | ----------- |
-| `accept`      | `accept`        | Accepted MIME-Types.                         | `string \| undefined` | `undefined` |
-| `compact`     | `compact`       | Set to true if file control should be small. | `boolean`             | `false`     |
-| `disabled`    | `disabled`      | Set when button is disabled.                 | `boolean`             | `false`     |
-| `label`       | `label`         | Label of the drop area.                      | `string \| undefined` | `undefined` |
-| `maxFileSize` | `max-file-size` | Allowed max file size in bytes.              | `number \| undefined` | `undefined` |
-| `multiple`    | `multiple`      | More than one file allowed.                  | `boolean`             | `false`     |
+| Property      | Attribute       | Description                                         | Type                  | Default     |
+| ------------- | --------------- | --------------------------------------------------- | --------------------- | ----------- |
+| `accept`      | `accept`        | Accepted MIME-Types.                                | `string \| undefined` | `undefined` |
+| `compact`     | `compact`       | Set to true if file control should be small.        | `boolean`             | `false`     |
+| `disabled`    | `disabled`      | Set when button is disabled.                        | `boolean`             | `false`     |
+| `label`       | `label`         | Label of the drop area.                             | `string \| undefined` | `undefined` |
+| `maxFileSize` | `max-file-size` | Allowed max file size in bytes.                     | `number \| undefined` | `undefined` |
+| `multiple`    | `multiple`      | More than one file allowed.                         | `boolean`             | `false`     |
+| `uploading`   | `uploading`     | Set to true to draw the control in a loading state. | `boolean`             | `false`     |
 
 
 ## Events
@@ -145,11 +155,13 @@ You can define a custom label via the `label` attribute
 ### Depends on
 
 - [six-icon](six-icon.html)
+- [six-spinner](six-spinner.html)
 
 ### Graph
 ```mermaid
 graph TD;
   six-file-upload --> six-icon
+  six-file-upload --> six-spinner
   style six-file-upload fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/docs/components/six-spinner.md
+++ b/docs/components/six-spinner.md
@@ -117,11 +117,13 @@ Spinner can be configured as animated SIX logo.
 ### Used by
 
  - [six-button](six-button.html)
+ - [six-file-upload](six-file-upload.html)
 
 ### Graph
 ```mermaid
 graph TD;
   six-button --> six-spinner
+  six-file-upload --> six-spinner
   style six-spinner fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/docs/examples/docs-demo-six-file-upload-5.vue
+++ b/docs/examples/docs-demo-six-file-upload-5.vue
@@ -1,0 +1,16 @@
+<template>
+<div>
+
+        <six-file-upload uploading></six-file-upload>
+      
+</div>
+</template>
+<style>
+
+</style>
+<script>
+export default {
+  name: 'docs-demo-six-file-upload-5',
+  mounted() {  }
+}
+</script>

--- a/examples/vue/src/views/FormView.vue
+++ b/examples/vue/src/views/FormView.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
+import type { SixFileUploadSuccessPayload } from '@six-group/ui-library';
 import {
   SixButton,
   SixCheckbox,
   SixDatepicker,
+  SixFileUpload,
   SixInput,
   SixLayoutGrid,
   SixMenuItem,
@@ -11,6 +13,7 @@ import {
   SixSelect,
   SixSwitch,
   SixTextarea,
+  SixGroupLabel,
 } from '@six-group/ui-library-vue';
 import { ref } from 'vue';
 
@@ -24,9 +27,22 @@ const radioValue = ref<string | undefined>('Option 3');
 const selectValues = ref(['Option 1', 'Option 2', 'Option 3', 'Option 4']);
 const selectValue = ref<string | undefined>('Option 2');
 const datepickerValue = ref<Date>(new Date());
+const file = ref('');
+const uploading = ref(false);
 
 const invalid = ref(false);
 const disabled = ref(false);
+
+const onFileSelected = async (event: CustomEvent<SixFileUploadSuccessPayload>) => {
+  const selectedfile = (event.detail as { file: File }).file;
+  file.value = selectedfile.name;
+  uploading.value = true;
+  // simulate the uploading operation
+  setTimeout(() => {
+    file.value = '';
+    uploading.value = false;
+  }, 3000);
+};
 </script>
 
 <template>
@@ -99,6 +115,7 @@ const disabled = ref(false);
       placeholder="Select one"
       :disabled="disabled"
       :invalid="invalid"
+      :filter="true"
       error-text="Select Error"
     >
       <six-menu-item v-for="value of selectValues" :key="value" :value="value">{{ value }}</six-menu-item>
@@ -112,6 +129,11 @@ const disabled = ref(false);
       error-text="Datepicker Error"
     ></six-datepicker>
     <pre>Value: {{ datepickerValue }}</pre>
+
+    <six-group-label label="File Upload">
+      <six-file-upload :uploading="uploading" @six-file-upload-success="onFileSelected"></six-file-upload>
+      <pre>Selected file: {{ file }}</pre>
+    </six-group-label>
 
     <div class="buttons">
       <six-button @click="invalid = !invalid">{{ invalid ? 'Hide Errors' : 'Show Errors' }}</six-button>

--- a/libraries/ui-library-angular/src/lib/stencil-generated/components.ts
+++ b/libraries/ui-library-angular/src/lib/stencil-generated/components.ts
@@ -534,14 +534,14 @@ export declare interface SixFileListItem extends Components.SixFileListItem {
 
 
 @ProxyCmp({
-  inputs: ['accept', 'compact', 'disabled', 'label', 'maxFileSize', 'multiple']
+  inputs: ['accept', 'compact', 'disabled', 'label', 'maxFileSize', 'multiple', 'uploading']
 })
 @Component({
   selector: 'six-file-upload',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['accept', 'compact', 'disabled', 'label', 'maxFileSize', 'multiple'],
+  inputs: ['accept', 'compact', 'disabled', 'label', 'maxFileSize', 'multiple', 'uploading'],
 })
 export class SixFileUpload {
   protected el: HTMLElement;

--- a/libraries/ui-library-vue/src/lib/stencil-generated/components.ts
+++ b/libraries/ui-library-vue/src/lib/stencil-generated/components.ts
@@ -216,6 +216,7 @@ export const SixFileUpload = /*@__PURE__*/ defineContainer<JSX.SixFileUpload>('s
   'accept',
   'multiple',
   'maxFileSize',
+  'uploading',
   'six-file-upload-success',
   'six-file-upload-failure'
 ]);

--- a/libraries/ui-library/src/components.d.ts
+++ b/libraries/ui-library/src/components.d.ts
@@ -682,6 +682,10 @@ export namespace Components {
           * More than one file allowed.
          */
         "multiple": false;
+        /**
+          * Set to true to draw the control in a loading state.
+         */
+        "uploading": boolean;
     }
     /**
      * @since 1.0
@@ -3794,6 +3798,10 @@ declare namespace LocalJSX {
           * Triggers when a file is added.
          */
         "onSix-file-upload-success"?: (event: SixFileUploadCustomEvent<SixFileUploadSuccessPayload>) => void;
+        /**
+          * Set to true to draw the control in a loading state.
+         */
+        "uploading"?: boolean;
     }
     /**
      * @since 1.0

--- a/libraries/ui-library/src/components/six-file-upload/index.html
+++ b/libraries/ui-library/src/components/six-file-upload/index.html
@@ -108,6 +108,12 @@
       <section>
         <six-file-upload compact></six-file-upload>
       </section>
+
+      <h3>Uploading</h3>
+
+      <section>
+        <six-file-upload uploading></six-file-upload>
+      </section>
     </div>
   </body>
 </html>

--- a/libraries/ui-library/src/components/six-file-upload/readme.md
+++ b/libraries/ui-library/src/components/six-file-upload/readme.md
@@ -7,14 +7,15 @@
 
 ## Properties
 
-| Property      | Attribute       | Description                                  | Type                  | Default     |
-| ------------- | --------------- | -------------------------------------------- | --------------------- | ----------- |
-| `accept`      | `accept`        | Accepted MIME-Types.                         | `string \| undefined` | `undefined` |
-| `compact`     | `compact`       | Set to true if file control should be small. | `boolean`             | `false`     |
-| `disabled`    | `disabled`      | Set when button is disabled.                 | `boolean`             | `false`     |
-| `label`       | `label`         | Label of the drop area.                      | `string \| undefined` | `undefined` |
-| `maxFileSize` | `max-file-size` | Allowed max file size in bytes.              | `number \| undefined` | `undefined` |
-| `multiple`    | `multiple`      | More than one file allowed.                  | `boolean`             | `false`     |
+| Property      | Attribute       | Description                                         | Type                  | Default     |
+| ------------- | --------------- | --------------------------------------------------- | --------------------- | ----------- |
+| `accept`      | `accept`        | Accepted MIME-Types.                                | `string \| undefined` | `undefined` |
+| `compact`     | `compact`       | Set to true if file control should be small.        | `boolean`             | `false`     |
+| `disabled`    | `disabled`      | Set when button is disabled.                        | `boolean`             | `false`     |
+| `label`       | `label`         | Label of the drop area.                             | `string \| undefined` | `undefined` |
+| `maxFileSize` | `max-file-size` | Allowed max file size in bytes.                     | `number \| undefined` | `undefined` |
+| `multiple`    | `multiple`      | More than one file allowed.                         | `boolean`             | `false`     |
+| `uploading`   | `uploading`     | Set to true to draw the control in a loading state. | `boolean`             | `false`     |
 
 
 ## Events
@@ -30,11 +31,13 @@
 ### Depends on
 
 - [six-icon](../six-icon)
+- [six-spinner](../six-spinner)
 
 ### Graph
 ```mermaid
 graph TD;
   six-file-upload --> six-icon
+  six-file-upload --> six-spinner
   style six-file-upload fill:#f9f,stroke:#333,stroke-width:4px
 ```
 

--- a/libraries/ui-library/src/components/six-file-upload/six-file-upload.tsx
+++ b/libraries/ui-library/src/components/six-file-upload/six-file-upload.tsx
@@ -1,5 +1,4 @@
 import { Component, Element, Event, EventEmitter, h, Listen, Prop, State } from '@stencil/core';
-
 interface ISingleFile {
   file: File;
 }
@@ -50,6 +49,9 @@ export class SixFileUpload {
   /** Allowed max file size in bytes. */
   @Prop() readonly maxFileSize?: number;
 
+  /** Set to true to draw the control in a loading state. */
+  @Prop({ reflect: true }) uploading = false;
+
   /** Triggers when a file is added. */
   @Event({ eventName: 'six-file-upload-success' }) success!: EventEmitter<SixFileUploadSuccessPayload>;
 
@@ -88,7 +90,7 @@ export class SixFileUpload {
   }
 
   private handleFiles = (files: FileList) => {
-    if (this.disabled || files.length === 0) {
+    if (this.disabled || files.length === 0 || this.uploading) {
       return;
     }
 
@@ -168,16 +170,17 @@ export class SixFileUpload {
       <div
         class={{
           'six-file-upload': true,
-          'six-file-upload--disabled': this.disabled,
+          'six-file-upload--disabled': this.disabled || this.uploading,
         }}
       >
         <Container
+          disabled={this.disabled || this.uploading}
           class={{
             'six-file-upload__container--compact': this.compact,
             'six-file-upload__container--full': !this.compact,
           }}
         >
-          {this.compact && (
+          {this.compact && !this.uploading && (
             <span slot="prefix">
               <six-icon class="six-file-upload__label-icon">arrow_circle_up</six-icon>
             </span>
@@ -189,17 +192,25 @@ export class SixFileUpload {
               'six-file-upload__drop-zone--compact': this.compact,
             }}
           >
-            <span>{this.renderLabel()}</span>
-            <input
-              class="six-file-upload__input"
-              type="file"
-              name="resume"
-              disabled={this.disabled}
-              accept={this.accept}
-              multiple={this.multiple}
-              onChange={this.onChange}
-              ref={(el) => (this.fileInput = el)}
-            />
+            {this.uploading ? (
+              <span>
+                <six-spinner /> Uploading...
+              </span>
+            ) : (
+              <div>
+                <span>{this.renderLabel()}</span>
+                <input
+                  class="six-file-upload__input"
+                  type="file"
+                  name="resume"
+                  disabled={this.disabled}
+                  accept={this.accept}
+                  multiple={this.multiple}
+                  onChange={this.onChange}
+                  ref={(el) => (this.fileInput = el)}
+                />
+              </div>
+            )}
           </div>
         </Container>
       </div>

--- a/libraries/ui-library/src/components/six-file-upload/test/six-file-upload.spec.tsx
+++ b/libraries/ui-library/src/components/six-file-upload/test/six-file-upload.spec.tsx
@@ -17,15 +17,17 @@ describe('six-file-upload', () => {
           <div class="six-file-upload">
             <six-card class="six-file-upload__container--full">
               <div class="six-file-upload__drop-zone">
-                <span>
+                <div>
                   <span>
-                    Drop files to upload, or
-                    <span class="six-file-upload__label--highlighted">
-                      browse
+                    <span>
+                      Drop files to upload, or
+                      <span class="six-file-upload__label--highlighted">
+                        browse
+                      </span>
                     </span>
                   </span>
-                </span>
-                <input class="six-file-upload__input" name="resume" type="file">
+                  <input class="six-file-upload__input" name="resume" type="file">
+                </div>
               </div>
             </six-card>
           </div>
@@ -44,10 +46,12 @@ describe('six-file-upload', () => {
           <div class="six-file-upload">
             <six-card class="six-file-upload__container--full">
               <div class="six-file-upload__drop-zone">
-                <span>
-                  some custom label
-                </span>
-                <input class="six-file-upload__input" name="resume" type="file">
+                <div>
+                  <span>
+                    some custom label
+                  </span>
+                  <input class="six-file-upload__input" name="resume" type="file">
+                </div>
               </div>
             </six-card>
           </div>
@@ -64,17 +68,19 @@ describe('six-file-upload', () => {
     expect(page.root).toEqualHtml(`
         <six-file-upload disabled="">
           <div class="six-file-upload six-file-upload--disabled">
-            <six-card class="six-file-upload__container--full">
+            <six-card class="six-file-upload__container--full" disabled="">
               <div class="six-file-upload__drop-zone">
-                <span>
+                <div>
                   <span>
-                    Drop files to upload, or
-                    <span class="six-file-upload__label--highlighted">
-                      browse
+                    <span>
+                      Drop files to upload, or
+                      <span class="six-file-upload__label--highlighted">
+                        browse
+                      </span>
                     </span>
                   </span>
-                </span>
-                <input class="six-file-upload__input" disabled="" name="resume" type="file">
+                  <input class="six-file-upload__input" disabled="" name="resume" type="file">
+                </div>
               </div>
             </six-card>
           </div>
@@ -98,12 +104,65 @@ describe('six-file-upload', () => {
                 </six-icon>
               </span>
               <div class="six-file-upload__drop-zone six-file-upload__drop-zone--compact">
-                <span>
-                  Upload
-                </span>
-                <input class="six-file-upload__input" name="resume" type="file">
+                <div>
+                  <span>
+                    Upload
+                  </span>
+                  <input class="six-file-upload__input" name="resume" type="file">
+                </div>
               </div>
             </six-button>
+          </div>
+        </six-file-upload>
+    `);
+  });
+
+  it('renders compact and disabled', async () => {
+    const page = await newSpecPage({
+      components: [SixFileUpload],
+      html: `<six-file-upload compact disabled></six-file-upload>`,
+    });
+
+    expect(page.root).toEqualHtml(`
+        <six-file-upload compact="" disabled="">
+          <div class="six-file-upload six-file-upload--disabled">
+            <six-button class="six-file-upload__container--compact" disabled="">
+              <span slot="prefix">
+                <six-icon class="six-file-upload__label-icon">
+                  arrow_circle_up
+                </six-icon>
+              </span>
+              <div class="six-file-upload__drop-zone six-file-upload__drop-zone--compact">
+                <div>
+                  <span>
+                    Upload
+                  </span>
+                  <input class="six-file-upload__input" disabled="" name="resume" type="file">
+                </div>
+              </div>
+            </six-button>
+          </div>
+        </six-file-upload>
+    `);
+  });
+
+  it('renders uploading', async () => {
+    const page = await newSpecPage({
+      components: [SixFileUpload],
+      html: `<six-file-upload uploading></six-file-upload>`,
+    });
+
+    expect(page.root).toEqualHtml(`
+        <six-file-upload uploading="">
+          <div class="six-file-upload six-file-upload--disabled">
+            <six-card class="six-file-upload__container--full" disabled="">
+              <div class="six-file-upload__drop-zone">
+                <span>
+                  <six-spinner></six-spinner>
+                  Uploading...
+                </span>
+              </div>
+            </six-card>
           </div>
         </six-file-upload>
     `);

--- a/libraries/ui-library/src/components/six-spinner/readme.md
+++ b/libraries/ui-library/src/components/six-spinner/readme.md
@@ -34,11 +34,13 @@
 ### Used by
 
  - [six-button](../six-button)
+ - [six-file-upload](../six-file-upload)
 
 ### Graph
 ```mermaid
 graph TD;
   six-button --> six-spinner
+  six-file-upload --> six-spinner
   style six-spinner fill:#f9f,stroke:#333,stroke-width:4px
 ```
 


### PR DESCRIPTION
### 🔗 Linked issue

- feature/202 https://github.com/six-group/six-webcomponents/issues/202
- fix/204 https://github.com/six-group/six-webcomponents/issues/204

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This is adding an `uploading ` optionnal attribute to the `six-file-upload` component.
When this attribute is set, the component shows a `six-spinner` and replaces the label text by 'Uploading...'.

In addition, the component now appears fully disabled even when it is in 'compact mode'.

I have also updated the Vue example; in the Form page, to show a `six-file-upload`. In the demo, the component goes into the 'uploading' state for three seconds and then returns to its default state, to simulate a (slow) file uplaod.
### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] I have updated the documentation accordingly.
- [x] All tests are passing
- [x] New/updated tests are included
- [x] I have updated the "upcoming" section inside _docs/changelog.md_ explaining the changes I contributed

**Other information:**
