### PR TITLE
Fix #241: Add part for the active tab indicator in the six-tab component

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `active-tab-indicator` part for the indicator in the six-tab component
+
 ### Changed
 
 ### Fixed

--- a/libraries/ui-library/src/components/six-tab/six-tab.tsx
+++ b/libraries/ui-library/src/components/six-tab/six-tab.tsx
@@ -103,6 +103,7 @@ export class SixTab {
           )}
         </div>
         <div
+          part={this.active ? 'active-tab-indicator' : ''}
           class={{
             tab__indicator: true,
             'tab__indicator--active': this.active,


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/six-group/six-webcomponents/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] I have updated the documentation accordingly.
- [x] All tests are passing
- [ ] New/updated tests are included
- [x] I have updated the "upcoming" section inside _docs/changelog.md_ explaining the changes I contributed

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
Usage:
```css
six-tab::part(active-tab-indicator) {
  display: none;
}
```