### PR TITLE
fix #172 Overflow when using autocomplete virtual scroll

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - `six-menu`: last item gets partially cut off when using virtual-scroll
+- `six-menu`: overflow when using virtual-scroll and autocomplete
 
 ## 4.2.4 - 2024-07-04
 

--- a/libraries/ui-library/src/components/six-menu/six-menu.tsx
+++ b/libraries/ui-library/src/components/six-menu/six-menu.tsx
@@ -153,6 +153,9 @@ export class SixMenu {
 
   private getItemsShown(): number {
     const defaultItemsShown = this.virtualScroll ? DEFAULT_NUMBER_OF_ITEMS_SHOWN_FOR_VIRTUAL_SCROLLING : 0;
+    if (this.items && this.items.length === 1) {
+      return 0;
+    }
     return this.itemsShown ?? defaultItemsShown;
   }
 
@@ -275,6 +278,8 @@ export class SixMenu {
     if (this.getItemsShown() > 0) {
       // calculate the proper height to show the correct number of items
       styles.height = `${(this.getItemsShown() ?? 0) * this.sixMenuItemHeight}px`;
+    } else if (this.items && this.items.length === 1) {
+      styles.height = 'auto';
     }
     return {
       ...styles,
@@ -296,11 +301,9 @@ export class SixMenu {
 
   private getScrollbarGhostStyle() {
     const styles: Partial<StyleDeclaration> = {};
-
-    if (this.virtualScroll && this.items !== null) {
+    if (this.virtualScroll && this.items !== null && this.items.length > 1) {
       styles.height = `${this.items.length * this.sixMenuItemHeight - this.itemSize * this.sixMenuItemHeight}px`;
     }
-
     return {
       ...styles,
     };


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/six-group/six-webcomponents/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### 🔗 Linked issue #172 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #172 
After fix:
![image](https://github.com/user-attachments/assets/df9515df-7e88-491a-9c52-572de10d00d4)


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] I have updated the documentation accordingly.
- [x] All tests are passing
- [ ] New/updated tests are included
- [x] I have updated the "upcoming" section inside _docs/changelog.md_ explaining the changes I contributed

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
