### PR TITLE
auto size issues type=number (fix #284)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `six-input`: fix auto size issues for type=number
 - `six-menu`: last item gets partially cut off when using virtual-scroll
 - `six-menu`: overflow when using virtual-scroll and autocomplete
 

--- a/libraries/ui-library/src/components/six-input/six-input.scss
+++ b/libraries/ui-library/src/components/six-input/six-input.scss
@@ -88,6 +88,7 @@
 
 .input__control {
   flex: 1 1 auto;
+  width: 100%;
   font-family: inherit;
   font-size: inherit;
   font-weight: inherit;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/six-group/six-webcomponents/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### 🔗 Linked issue

#284 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### Description

Fix issue of auto sizing inputs with type=number. 

