### PR TITLE
add --height property to six-textarea

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Upcoming
 
+### Added
+
+- `six-textarea`: added CSS variable `--height` to set the initial height of the textarea component
+
 ### Fixed
 
 - `six-menu`: last item gets partially cut off when using virtual-scroll

--- a/docs/components/six-textarea.md
+++ b/docs/components/six-textarea.md
@@ -106,6 +106,27 @@ Textareas will automatically resize to expand to fit their content when `resize`
 ```
 
 
+### Custom Height
+
+Use the css property `--height` to set a fixed initial height of six-textarea
+
+<docs-demo-six-textarea-9></docs-demo-six-textarea-9>
+
+```html
+<six-textarea style="--height: 150px"></six-textarea>
+```
+
+
+With `rows=1` and `--height` set to a six css height variable the height matches other six inputs
+
+<docs-demo-six-textarea-10></docs-demo-six-textarea-10>
+
+```html
+<six-textarea rows="1" style="--height: var(--six-height-medium)"></six-textarea>
+<six-input></six-input>
+```
+
+
 ## Events Discalimer
 
 The events of our webcommponents should follow native web elements as much as possible.
@@ -122,7 +143,7 @@ This means input, change and blur should be fired the same as when using native 
 
 You can play with the following native and six-input elements to see that the event firing is the same
 
-<docs-demo-six-textarea-9></docs-demo-six-textarea-9>
+<docs-demo-six-textarea-11></docs-demo-six-textarea-11>
 
 ```html
 <div style="font-size: 1rem; font-weight: bold; padding-bottom: 1rem">Native Input Element</div>
@@ -188,7 +209,7 @@ warning There are two caveats when using the `error-text` prop/slot:
 
 The `error-text` prop accepts either a simple string message, or a list of messages.
 
-<docs-demo-six-textarea-10></docs-demo-six-textarea-10>
+<docs-demo-six-textarea-12></docs-demo-six-textarea-12>
 
 ```html
 <six-textarea label="Simple string message" error-text="This is a simple string message" invalid>
@@ -196,7 +217,7 @@ The `error-text` prop accepts either a simple string message, or a list of messa
 ```
 
 
-<docs-demo-six-textarea-11></docs-demo-six-textarea-11>
+<docs-demo-six-textarea-13></docs-demo-six-textarea-13>
 
 ```html
 <six-textarea id="multiple-error-text" label="List of string message" invalid></six-textarea>
@@ -210,7 +231,7 @@ The `error-text` prop accepts either a simple string message, or a list of messa
 
 When using the `error-text` slot, it is recommended to use the `six-error` component to wrap the error message(s). This will provide the correct styling out of the box
 
-<docs-demo-six-textarea-12></docs-demo-six-textarea-12>
+<docs-demo-six-textarea-14></docs-demo-six-textarea-14>
 
 ```html
 <six-textarea invalid>
@@ -358,6 +379,13 @@ Type: `Promise<void | undefined>`
 | `"help-text"`    | The textarea help text.                                         |
 | `"label"`        | The textarea label.                                             |
 | `"textarea"`     | The textarea control.                                           |
+
+
+## CSS Custom Properties
+
+| Name       | Description          |
+| ---------- | -------------------- |
+| `--height` | The textarea height. |
 
 
 ## Dependencies

--- a/docs/examples/docs-demo-six-textarea-10.vue
+++ b/docs/examples/docs-demo-six-textarea-10.vue
@@ -1,8 +1,8 @@
 <template>
 <div>
 
-        <six-textarea label="Simple string message" error-text="This is a simple string message" invalid>
-        </six-textarea>
+        <six-textarea rows="1" style="--height: var(--six-height-medium)"></six-textarea>
+        <six-input></six-input>
       
 </div>
 </template>

--- a/docs/examples/docs-demo-six-textarea-11.vue
+++ b/docs/examples/docs-demo-six-textarea-11.vue
@@ -1,7 +1,28 @@
 <template>
 <div>
 
-        <six-textarea id="multiple-error-text" label="List of string message" invalid></six-textarea>
+        <div style="font-size: 1rem; font-weight: bold; padding-bottom: 1rem">Native Input Element</div>
+        <textarea type="text" id="native-textarea" name="type"></textarea>
+        <div style="padding-bottom: 0.5rem">
+          <div style="padding-top: 1rem">Event Firing History:</div>
+          <ul id="native-events-list"></ul>
+        </div>
+
+        <div style="font-size: 1rem; font-weight: bold; padding-bottom: 1rem">SIX Input Element</div>
+        <six-textarea           label="Events"
+          help-text="Check what event is fired when..."
+          id="custom-six-textarea"
+        ></six-textarea>
+        <six-button style="padding-top: 0.5rem" id="event-setting-btn">Set Value</six-button>
+        <div style="padding-bottom: 0.5rem">
+          <div style="padding-top: 1rem">Event Firing History:</div>
+          <ul id="events-list"></ul>
+        </div>
+        <div style="padding-bottom: 0.5rem">
+          <div style="padding-top: 1rem">Event Firing History for six-textarea-value-change:</div>
+          <ul id="events-list-value-change"></ul>
+        </div>
+
         
       
 </div>
@@ -13,9 +34,31 @@
 export default {
   name: 'docs-demo-six-textarea-11',
   mounted() { 
-          const sixTextarea = document.getElementById('multiple-error-text');
-          sixTextarea.errorText = ['Message 1', 'Message 2'];
-          sixTextarea.errorTextCount = 3;
+          const nativeTextarea = document.getElementById('native-textarea');
+          const inputEl = document.getElementById('custom-six-textarea');
+          const eventList = document.getElementById('events-list');
+          const eventListValueChange = document.getElementById('events-list-value-change');
+          const nativeEventList = document.getElementById('native-events-list');
+          const eventSettingBtn = document.getElementById('event-setting-btn');
+
+          const logEvent = (eventName, el, color) => (event) => {
+            const value = event.target.value;
+            el.innerHTML = `${el.innerHTML}<li><span style="font-weight: bold; color: ${color};">${eventName}:</span> ${value}</li>`;
+          };
+          inputEl.addEventListener('six-textarea-input', logEvent('input', eventList, 'blue'));
+          inputEl.addEventListener('six-textarea-change', logEvent('change', eventList, 'red'));
+          inputEl.addEventListener('six-textarea-blur', logEvent('blur', eventList, 'green'));
+          inputEl.addEventListener('six-textarea-value-change', logEvent('value-change', eventListValueChange));
+
+          nativeTextarea.addEventListener('input', logEvent('input', nativeEventList, 'blue'));
+          nativeTextarea.addEventListener('change', logEvent('change', nativeEventList, 'red'));
+          nativeTextarea.addEventListener('blur', logEvent('blur', nativeEventList, 'green'));
+
+          eventSettingBtn.addEventListener('click', () => {
+            const someString = 'dynamically set value';
+            inputEl.value = someString;
+            nativeTextarea.value = someString;
+          });
          }
 }
 </script>

--- a/docs/examples/docs-demo-six-textarea-12.vue
+++ b/docs/examples/docs-demo-six-textarea-12.vue
@@ -1,11 +1,7 @@
 <template>
 <div>
 
-        <six-textarea invalid>
-          <div slot="error-text">
-            <six-error               >An error message
-              <a href="https://github.com/six-group/six-webcomponents" target="_blank">with a link</a></six-error>
-          </div>
+        <six-textarea label="Simple string message" error-text="This is a simple string message" invalid>
         </six-textarea>
       
 </div>

--- a/docs/examples/docs-demo-six-textarea-13.vue
+++ b/docs/examples/docs-demo-six-textarea-13.vue
@@ -1,0 +1,21 @@
+<template>
+<div>
+
+        <six-textarea id="multiple-error-text" label="List of string message" invalid></six-textarea>
+        
+      
+</div>
+</template>
+<style>
+
+</style>
+<script>
+export default {
+  name: 'docs-demo-six-textarea-13',
+  mounted() { 
+          const sixTextarea = document.getElementById('multiple-error-text');
+          sixTextarea.errorText = ['Message 1', 'Message 2'];
+          sixTextarea.errorTextCount = 3;
+         }
+}
+</script>

--- a/docs/examples/docs-demo-six-textarea-14.vue
+++ b/docs/examples/docs-demo-six-textarea-14.vue
@@ -1,0 +1,21 @@
+<template>
+<div>
+
+        <six-textarea invalid>
+          <div slot="error-text">
+            <six-error               >An error message
+              <a href="https://github.com/six-group/six-webcomponents" target="_blank">with a link</a></six-error>
+          </div>
+        </six-textarea>
+      
+</div>
+</template>
+<style>
+
+</style>
+<script>
+export default {
+  name: 'docs-demo-six-textarea-14',
+  mounted() {  }
+}
+</script>

--- a/docs/examples/docs-demo-six-textarea-9.vue
+++ b/docs/examples/docs-demo-six-textarea-9.vue
@@ -1,29 +1,7 @@
 <template>
 <div>
 
-        <div style="font-size: 1rem; font-weight: bold; padding-bottom: 1rem">Native Input Element</div>
-        <textarea type="text" id="native-textarea" name="type"></textarea>
-        <div style="padding-bottom: 0.5rem">
-          <div style="padding-top: 1rem">Event Firing History:</div>
-          <ul id="native-events-list"></ul>
-        </div>
-
-        <div style="font-size: 1rem; font-weight: bold; padding-bottom: 1rem">SIX Input Element</div>
-        <six-textarea           label="Events"
-          help-text="Check what event is fired when..."
-          id="custom-six-textarea"
-        ></six-textarea>
-        <six-button style="padding-top: 0.5rem" id="event-setting-btn">Set Value</six-button>
-        <div style="padding-bottom: 0.5rem">
-          <div style="padding-top: 1rem">Event Firing History:</div>
-          <ul id="events-list"></ul>
-        </div>
-        <div style="padding-bottom: 0.5rem">
-          <div style="padding-top: 1rem">Event Firing History for six-textarea-value-change:</div>
-          <ul id="events-list-value-change"></ul>
-        </div>
-
-        
+        <six-textarea style="--height: 150px"></six-textarea>
       
 </div>
 </template>
@@ -33,32 +11,6 @@
 <script>
 export default {
   name: 'docs-demo-six-textarea-9',
-  mounted() { 
-          const nativeTextarea = document.getElementById('native-textarea');
-          const inputEl = document.getElementById('custom-six-textarea');
-          const eventList = document.getElementById('events-list');
-          const eventListValueChange = document.getElementById('events-list-value-change');
-          const nativeEventList = document.getElementById('native-events-list');
-          const eventSettingBtn = document.getElementById('event-setting-btn');
-
-          const logEvent = (eventName, el, color) => (event) => {
-            const value = event.target.value;
-            el.innerHTML = `${el.innerHTML}<li><span style="font-weight: bold; color: ${color};">${eventName}:</span> ${value}</li>`;
-          };
-          inputEl.addEventListener('six-textarea-input', logEvent('input', eventList, 'blue'));
-          inputEl.addEventListener('six-textarea-change', logEvent('change', eventList, 'red'));
-          inputEl.addEventListener('six-textarea-blur', logEvent('blur', eventList, 'green'));
-          inputEl.addEventListener('six-textarea-value-change', logEvent('value-change', eventListValueChange));
-
-          nativeTextarea.addEventListener('input', logEvent('input', nativeEventList, 'blue'));
-          nativeTextarea.addEventListener('change', logEvent('change', nativeEventList, 'red'));
-          nativeTextarea.addEventListener('blur', logEvent('blur', nativeEventList, 'green'));
-
-          eventSettingBtn.addEventListener('click', () => {
-            const someString = 'dynamically set value';
-            inputEl.value = someString;
-            nativeTextarea.value = someString;
-          });
-         }
+  mounted() {  }
 }
 </script>

--- a/libraries/ui-library/src/components/six-textarea/index.html
+++ b/libraries/ui-library/src/components/six-textarea/index.html
@@ -83,6 +83,21 @@
         <six-textarea resize="auto"></six-textarea>
       </section>
 
+      <h3>Custom Height</h3>
+      <p>Use the css property <code>--height</code> to set a fixed initial height of six-textarea</p>
+      <section class="demo" style="width: 300px">
+        <six-textarea style="--height: 150px"></six-textarea>
+      </section>
+
+      <p>
+        With <code>rows=1</code> and <code>--height</code> set to a six css height variable the height matches other six
+        inputs
+      </p>
+      <section class="demo" style="width: 600px; display: grid; grid-template-columns: 200px 200px; gap: 10px">
+        <six-textarea rows="1" style="--height: var(--six-height-medium)"></six-textarea>
+        <six-input></six-input>
+      </section>
+
       <h2>Events Discalimer</h2>
 
       <p>The events of our webcommponents should follow native web elements as much as possible.</p>

--- a/libraries/ui-library/src/components/six-textarea/readme.md
+++ b/libraries/ui-library/src/components/six-textarea/readme.md
@@ -139,6 +139,13 @@ Type: `Promise<void | undefined>`
 | `"textarea"`     | The textarea control.                                           |
 
 
+## CSS Custom Properties
+
+| Name       | Description          |
+| ---------- | -------------------- |
+| `--height` | The textarea height. |
+
+
 ## Dependencies
 
 ### Depends on

--- a/libraries/ui-library/src/components/six-textarea/six-textarea.scss
+++ b/libraries/ui-library/src/components/six-textarea/six-textarea.scss
@@ -1,7 +1,11 @@
 @import 'src/global/component';
 @import '../../functional-components/form-control/form-control';
 
+/**
+ * @prop --height: The textarea height.
+ */
 :host {
+  --height: 100%;
   display: block;
 }
 
@@ -57,6 +61,7 @@
 
 .textarea__control {
   flex: 1 1 auto;
+  height: calc(var(--height) - 2 * var(--six-border-width));
   font-family: inherit;
   font-size: inherit;
   font-weight: inherit;


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/six-group/six-webcomponents/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### 🔗 Linked issue
#285 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 👌 Enhancement 

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Added a CSS property --height for the six-textarea component. This property provides an easy fix for the height issues mentioned in #285. With the new CSS property --height one can set directly the height of the six-textarea component. By setting the --height property to one of the six height variables (--six-height-small, --six-height-medium, --six-height-large) the six-textarea with rows=1 will have the same height as other six inputs with the respective size.   
