### PR TITLE
Fix/278 six select autocomplete displays value instead of label

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `six-select`: fix displaying label instead of value in autocomplete mode
+
 ### Changed
 
 ## 4.2.5 - 2024-09-12

--- a/libraries/ui-library/src/components/six-select/six-select.tsx
+++ b/libraries/ui-library/src/components/six-select/six-select.tsx
@@ -243,7 +243,9 @@ export class SixSelect {
           event.stopPropagation();
         }, this.inputDebounce)
       );
-      autocompleteInput.value = Array.isArray(this.value) ? this.value.join(',') : this.value;
+  
+      const selectedLabel = this.displayedValues.join(', ');
+      autocompleteInput.value = selectedLabel;
     }
   }
 
@@ -486,8 +488,9 @@ export class SixSelect {
     const checkedItems = getCheckedItems(convertToValidArrayValue(this.value), mainItems);
     this.displayedValues = checkedItems.map((i) => this.getItemLabel(i));
 
-    if (this.autocomplete && this.autocompleteInput != null) {
-      this.autocompleteInput.value = Array.isArray(this.value) ? this.value.join(',') : this.value;
+    if (this.autocomplete && this.autocompleteInput != null && !this.hasFocus) {
+      const selectedLabel = this.displayedValues.join(', ');
+      this.autocompleteInput.value = selectedLabel;
     }
 
     requestAnimationFrame(() => {

--- a/libraries/ui-library/src/components/six-select/six-select.tsx
+++ b/libraries/ui-library/src/components/six-select/six-select.tsx
@@ -243,7 +243,7 @@ export class SixSelect {
           event.stopPropagation();
         }, this.inputDebounce)
       );
-  
+
       const selectedLabel = this.displayedValues.join(', ');
       autocompleteInput.value = selectedLabel;
     }


### PR DESCRIPTION
### 🔗 Linked issue #278

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Resolves #278

![image](https://github.com/user-attachments/assets/68b8cb57-d141-4ba7-9c98-1c279ec56430)


### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] I have updated the documentation accordingly.
- [x] All tests are passing
- [ ] New/updated tests are included
- [x] I have updated the "upcoming" section inside _docs/changelog.md_ explaining the changes I contributed

