### PR TITLE
Fix/275 six select: show dropdown after the value is cleared

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - `six-select`: fix displaying label instead of value in autocomplete mode
+- `six-select`: show dropdown after the value is cleared
 
 ### Changed
 

--- a/libraries/ui-library/src/components/six-select/six-select.tsx
+++ b/libraries/ui-library/src/components/six-select/six-select.tsx
@@ -241,6 +241,10 @@ export class SixSelect {
           this.value = autocompleteInput.value;
           this.sixChange.emit({ value: this.value, isSelected: false });
           event.stopPropagation();
+
+          if (this.virtualScroll || this.value.length > 0) {
+            this.dropdown?.show();
+          }
         }, this.inputDebounce)
       );
 
@@ -303,7 +307,8 @@ export class SixSelect {
   private handleClearClick = async (event: MouseEvent) => {
     event.stopPropagation();
     await this.clearValues();
-    await this.dropdown?.hide();
+    await this.dropdown?.show();
+    await this.setFocus();
     this.sixChange.emit({ value: this.value, isSelected: true });
   };
 


### PR DESCRIPTION
### 🔗 Linked issue #275 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #275 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] I have updated the documentation accordingly.
- [x] All tests are passing
- [ ] New/updated tests are included
- [x] I have updated the "upcoming" section inside _docs/changelog.md_ explaining the changes I contributed
