### PR TITLE
six-button custom padding variable added

### DIFF
--- a/docs/components/six-button.md
+++ b/docs/components/six-button.md
@@ -1,6 +1,5 @@
 # Button
 
-
 Buttons represent actions that are available to the user.
 
 <docs-demo-six-button-0></docs-demo-six-button-0>
@@ -8,7 +7,6 @@ Buttons represent actions that are available to the user.
 ```html
 <six-button>Button</six-button>
 ```
-
 
 ## Examples
 
@@ -28,7 +26,6 @@ Use the `type` attribute to set the button's type.
 <six-button type="action">Action</six-button>
 <six-button type="action-outline">Action Outline</six-button>
 ```
-
 
 Notice on different background colors that the Link button has no background
 
@@ -57,7 +54,6 @@ Notice on different background colors that the Link button has no background
 </div>
 ```
 
-
 ### Sizes
 
 Use the `size` prop to change a button's size.
@@ -70,7 +66,6 @@ Use the `size` prop to change a button's size.
 <six-button size="large">Large</six-button>
 ```
 
-
 ### Pill Buttons
 
 Use the `pill` prop to give buttons rounded edges.
@@ -82,7 +77,6 @@ Use the `pill` prop to give buttons rounded edges.
 <six-button size="medium" pill>Medium</six-button>
 <six-button size="large" pill>Large</six-button>
 ```
-
 
 ### Circle buttons
 
@@ -111,10 +105,10 @@ Use the `circle` prop to create circular icon buttons.
 </six-button>
 ```
 
-
 ### Link Buttons
 
-Use the `link` type to create text buttons that share the same size as regular buttons but don't have backgrounds or borders.
+Use the `link` type to create text buttons that share the same size as regular buttons but don't
+have backgrounds or borders.
 
 <docs-demo-six-button-6></docs-demo-six-button-6>
 
@@ -124,10 +118,12 @@ Use the `link` type to create text buttons that share the same size as regular b
 <six-button type="link" size="large">Large</six-button>
 ```
 
-
 ### Link buttons
 
-It's often helpful to have a button that works like a link. This is possible by setting the `href` attribute, which will make the component render an `<a>` under the hood. This gives you all the default link behavior the browser provides (e.g. CMD/CTRL/SHIFT + CLICK) and exposes the `target` and `download` attributes.
+It's often helpful to have a button that works like a link. This is possible by setting the `href`
+attribute, which will make the component render an `<a>` under the hood. This gives you all the
+default link behavior the browser provides (e.g. CMD/CTRL/SHIFT + CLICK) and exposes the `target`
+and `download` attributes.
 
 <docs-demo-six-button-7></docs-demo-six-button-7>
 
@@ -138,21 +134,25 @@ It's often helpful to have a button that works like a link. This is possible by 
 <six-button href="https://www.six-group.com/" disabled>Disabled</six-button>
 ```
 
-
-When a `target` is set, the link will receive `rel="noreferrer noopener"` [for security reasons](https://mathiasbynens.github.io/rel-noopener/).
+When a `target` is set, the link will receive `rel="noreferrer noopener"`
+[for security reasons](https://mathiasbynens.github.io/rel-noopener/).
 
 ### Setting a Custom Width
 
-As expected, buttons can be given a custom width by setting its `width`. This is useful for making buttons span the full width of their container on smaller screens.
+As expected, buttons can be given a custom width by setting its `width`. This is useful for making
+buttons span the full width of their container on smaller screens.
 
 <docs-demo-six-button-8></docs-demo-six-button-8>
 
 ```html
-<six-button type="secondary" size="small" style="width: 100%; margin-bottom: 1rem">Small</six-button>
-<six-button type="secondary" size="medium" style="width: 100%; margin-bottom: 1rem">Medium</six-button>
+<six-button type="secondary" size="small" style="width: 100%; margin-bottom: 1rem"
+  >Small</six-button
+>
+<six-button type="secondary" size="medium" style="width: 100%; margin-bottom: 1rem"
+  >Medium</six-button
+>
 <six-button type="secondary" size="large" style="width: 100%">Large</six-button>
 ```
-
 
 ### Prefix and Suffix Icons
 
@@ -162,7 +162,6 @@ Use the `prefix` and `suffix` slots to add icons.
 
 ```html
 <six-button size="small">
-  
   <span slot="prefix"><six-icon size="xSmall">settings</six-icon></span>
   Settings
 </six-button>
@@ -178,7 +177,7 @@ Use the `prefix` and `suffix` slots to add icons.
   Open
 </six-button>
 
-<br><br>
+<br /><br />
 
 <six-button>
   <span slot="prefix"><six-icon size="small">settings</six-icon></span>
@@ -196,7 +195,7 @@ Use the `prefix` and `suffix` slots to add icons.
   Open
 </six-button>
 
-<br><br>
+<br /><br />
 
 <six-button size="large">
   <span slot="prefix"><six-icon size="medium">settings</six-icon></span>
@@ -215,10 +214,10 @@ Use the `prefix` and `suffix` slots to add icons.
 </six-button>
 ```
 
-
 ### Caret
 
-Use the `caret` prop to add a dropdown indicator when a button will trigger a dropdown, menu, or popover.
+Use the `caret` prop to add a dropdown indicator when a button will trigger a dropdown, menu, or
+popover.
 
 <docs-demo-six-button-10></docs-demo-six-button-10>
 
@@ -228,22 +227,21 @@ Use the `caret` prop to add a dropdown indicator when a button will trigger a dr
 <six-button size="large" caret>Large</six-button>
 ```
 
-
 ### Loading
 
-Use the `loading` prop to make a button busy. The width will remain the same as before, preventing adjacent elements from moving around. Clicks will be suppressed until the loading state is removed.
+Use the `loading` prop to make a button busy. The width will remain the same as before, preventing
+adjacent elements from moving around. Clicks will be suppressed until the loading state is removed.
 
 <docs-demo-six-button-11></docs-demo-six-button-11>
 
 ```html
-<six-button type="secondary" loading>Secondary</six-button>
-<six-button loading>Primary</six-button>
+<six-button type="secondary" loading>Secondary</six-button> <six-button loading>Primary</six-button>
 ```
-
 
 ### Disabled
 
-Use the `disabled` prop to disable a button. Clicks will be suppressed until the disabled state is removed.
+Use the `disabled` prop to disable a button. Clicks will be suppressed until the disabled state is
+removed.
 
 <docs-demo-six-button-12></docs-demo-six-button-12>
 
@@ -260,10 +258,7 @@ Use the `disabled` prop to disable a button. Clicks will be suppressed until the
 <six-button type="action-outline" disabled>Action Outline</six-button>
 ```
 
-
-
 <!-- Auto Generated Below -->
-
 
 ## Properties
 
@@ -284,14 +279,12 @@ Use the `disabled` prop to disable a button. Clicks will be suppressed until the
 | `type`     | `type`     | The button's type.                                                                                     | `"action" \| "action-outline" \| "danger" \| "link" \| "primary" \| "secondary" \| "success" \| "warning"` | `'primary'` |
 | `value`    | `value`    | An optional value for the button. Ignored when `href` is set.                                          | `string`                                                                                                   | `''`        |
 
-
 ## Events
 
 | Event              | Description                          | Type                     |
 | ------------------ | ------------------------------------ | ------------------------ |
 | `six-button-blur`  | Emitted when the button loses focus. | `CustomEvent<undefined>` |
 | `six-button-focus` | Emitted when the button gains focus. | `CustomEvent<undefined>` |
-
 
 ## Methods
 
@@ -302,8 +295,6 @@ Removes focus from the button.
 #### Returns
 
 Type: `Promise<void>`
-
-
 
 ### `setFocus(options?: FocusOptions) => Promise<void>`
 
@@ -319,9 +310,6 @@ Sets focus on the button.
 
 Type: `Promise<void>`
 
-
-
-
 ## Slots
 
 | Slot       | Description                                               |
@@ -329,7 +317,6 @@ Type: `Promise<void>`
 |            | The button's label.                                       |
 | `"prefix"` | Used to prepend an icon or similar element to the button. |
 | `"suffix"` | Used to append an icon or similar element to the button.  |
-
 
 ## Shadow Parts
 
@@ -341,18 +328,26 @@ Type: `Promise<void>`
 | `"prefix"` | The prefix container.         |
 | `"suffix"` | The suffix container.         |
 
+## CSS Custom Properties
+
+| Name                            | Description                 |
+| ------------------------------- | --------------------------- |
+| `--six-button-padding`          | Padding of the button.      |
+| `--six-button-font-size-medium` | Font size of medium button. |
+| `--six-button-font-size-large`  | Font size of large button.  |
 
 ## Dependencies
 
 ### Used by
 
- - [six-select](six-select.html)
+- [six-select](six-select.html)
 
 ### Depends on
 
 - [six-spinner](six-spinner.html)
 
 ### Graph
+
 ```mermaid
 graph TD;
   six-button --> six-spinner
@@ -360,6 +355,6 @@ graph TD;
   style six-button fill:#f9f,stroke:#333,stroke-width:4px
 ```
 
-----------------------------------------------
+---
 
 Copyright © 2021-present SIX-Group

--- a/libraries/ui-library/src/components/six-button/six-button.scss
+++ b/libraries/ui-library/src/components/six-button/six-button.scss
@@ -7,8 +7,8 @@
 }
 
 .button {
-  display: inline-flex;
-  align-items: stretch;
+  display: flex;
+  align-items: center;
   justify-content: center;
   width: 100%;
   border-style: solid;
@@ -20,7 +20,7 @@
   user-select: none;
   white-space: nowrap;
   vertical-align: middle;
-  padding: 0;
+  padding: var(--six-button-padding);
   transition: var(--six-transition-fast) background-color, var(--six-transition-fast) color,
     var(--six-transition-fast) border, var(--six-transition-fast) box-shadow;
   cursor: inherit;

--- a/libraries/ui-library/src/global/base.css
+++ b/libraries/ui-library/src/global/base.css
@@ -84,6 +84,7 @@ body > div.container {
 
   --six-button-font-size-medium: var(--six-font-size-medium);
   --six-button-font-size-large: var(--six-font-size-large);
+  --six-button-padding: 0;
 
   --six-focus-shadow: 0 0 0 var(--six-focus-offset-input);
   --six-input-focus-shadow: var(--six-focus-shadow) var(--six-input-border-color-focus);


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/six-group/six-webcomponents/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
I just added the `--six-button-padding` variable so you can change padding of the button if you want to.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] I have updated the documentation accordingly.
- [x] All tests are passing
- [x] New/updated tests are included
- [ ] I have updated the "upcoming" section inside _docs/changelog.md_ explaining the changes I contributed

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
<img width="853" alt="Bildschirmfoto 2024-10-31 um 10 40 22" src="https://github.com/user-attachments/assets/b26140c9-2241-4ab3-bd45-2b44725c33a5">
