### PR TITLE
chore: use @fontsource for material font

### DIFF
--- a/libraries/ui-library/package.json
+++ b/libraries/ui-library/package.json
@@ -37,7 +37,9 @@
     "@types/resize-observer-browser": "^0.1.5"
   },
   "devDependencies": {
-    "@fontsource/noto-sans": "^5.1.0",
+    "@fontsource/noto-sans": "^5.1.1",
+    "@fontsource/material-icons": "^5.1.1",
+    "@fontsource/material-icons-outlined": "^5.1.1",
     "@popperjs/core": "^2.5.3",
     "@stencil-community/eslint-plugin": "0.x",
     "@stencil/angular-output-target": "0.x",
@@ -46,7 +48,6 @@
     "@stencil/sass": "^3.0.7",
     "@typescript-eslint/eslint-plugin": "^6.15.0",
     "@typescript-eslint/parser": "^6.15.0",
-    "material-icons": "^1.13.12",
     "replace-in-file": "^6.3.5",
     "rimraf": "^3.0.2"
   },

--- a/libraries/ui-library/src/global/base.css
+++ b/libraries/ui-library/src/global/base.css
@@ -1,4 +1,5 @@
-@import '~material-icons/iconfont/material-icons.css';
+@import '~@fontsource/material-icons/latin.css';
+@import '~@fontsource/material-icons-outlined/latin.css';
 @import '~@fontsource/noto-sans/latin.css';
 @import 'base/colors.css';
 @import 'base/typography.css';

--- a/libraries/ui-library/stencil.config.ts
+++ b/libraries/ui-library/stencil.config.ts
@@ -46,7 +46,8 @@ export const config: Config = {
       type: 'dist',
       esmLoaderPath: '../loader',
       copy: [
-        { src: '../../../node_modules/material-icons/iconfont/material-icons*.*', dest: '.', warn: true },
+        { src: '../../../node_modules/@fontsource/material-icons/files/*', dest: './files', warn: true },
+        { src: '../../../node_modules/@fontsource/material-icons-outlined/files/*', dest: './files', warn: true },
         { src: '../../../node_modules/@fontsource/noto-sans/files/*', dest: './files', warn: true },
         { src: './assets/**/*', dest: '.', warn: true, keepDirStructure: true },
       ],
@@ -71,7 +72,8 @@ export const config: Config = {
       type: 'www',
       serviceWorker: null, // disable service workers
       copy: [
-        { src: '../../../node_modules/material-icons/iconfont/material-icons*.*', dest: 'build', warn: true },
+        { src: '../../../node_modules/@fontsource/material-icons/files/*', dest: 'build/files', warn: true },
+        { src: '../../../node_modules/@fontsource/material-icons-outlined/files/*', dest: 'build/files', warn: true },
         { src: '../../../node_modules/@fontsource/noto-sans/files/*', dest: 'build/files', warn: true },
         { src: '**/*.html' },
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1351,7 +1351,9 @@
         "@types/resize-observer-browser": "^0.1.5"
       },
       "devDependencies": {
-        "@fontsource/noto-sans": "^5.1.0",
+        "@fontsource/material-icons": "^5.1.1",
+        "@fontsource/material-icons-outlined": "^5.1.1",
+        "@fontsource/noto-sans": "^5.1.1",
         "@popperjs/core": "^2.5.3",
         "@stencil-community/eslint-plugin": "0.x",
         "@stencil/angular-output-target": "0.x",
@@ -1360,7 +1362,6 @@
         "@stencil/vue-output-target": "0.x",
         "@typescript-eslint/eslint-plugin": "^6.15.0",
         "@typescript-eslint/parser": "^6.15.0",
-        "material-icons": "^1.13.12",
         "replace-in-file": "^6.3.5",
         "rimraf": "^3.0.2"
       },
@@ -5774,10 +5775,22 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@fontsource/material-icons": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@fontsource/material-icons/-/material-icons-5.1.1.tgz",
+      "integrity": "sha512-l1EhBIh9US1RMiiKEJ+/FTFvHZIU3cpn0MmxSZA6Ip2C/Szwca6h2xqNg/OTIOFWADune7b/rhtypeDbjHrZzA==",
+      "dev": true
+    },
+    "node_modules/@fontsource/material-icons-outlined": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@fontsource/material-icons-outlined/-/material-icons-outlined-5.1.1.tgz",
+      "integrity": "sha512-HjWe3anHu9RptoAvm2UF6MPXkwsbFbH+vkg48GRIhXPsXyfmZteGHVFZpPxaZnakrmnLXDxUnnKSj7zzqk+Rhg==",
+      "dev": true
+    },
     "node_modules/@fontsource/noto-sans": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@fontsource/noto-sans/-/noto-sans-5.1.0.tgz",
-      "integrity": "sha512-P6X+ynPOteCsbUHI7rU4UIpRJcuraJ3OllKqPIjKgxPZS0yPtxFyquADb4SmcgZosRrgqDy34/dcSIhio3Qx4Q==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@fontsource/noto-sans/-/noto-sans-5.1.1.tgz",
+      "integrity": "sha512-WesuII3BzvzVr0JqYIgnEeJPwXvpFAo9tNCMH1AqoLSCdStKJugMaIcVJ/sT+Pw9ytIlUO3ccbqbe+BhhsXm9g==",
       "dev": true
     },
     "node_modules/@gar/promisify": {
@@ -16863,12 +16876,6 @@
       "engines": {
         "node": ">= 18"
       }
-    },
-    "node_modules/material-icons": {
-      "version": "1.13.12",
-      "resolved": "https://registry.npmjs.org/material-icons/-/material-icons-1.13.12.tgz",
-      "integrity": "sha512-/2YoaB79IjUK2B2JB+vIXXYGtBfHb/XG66LvoKVM5ykHW7yfrV5SP6d7KLX6iijY6/G9GqwgtPQ/sbhFnOURVA==",
-      "dev": true
     },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.0",


### PR DESCRIPTION
Simply to be able to use the same config as the noto-font
