### PR TITLE
feat: simplify six-button prefix and suffix icon use

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - `six-logo`: removed inline style tag
 - `six-timepicker`: removed unnecessary bottom padding
+- `six-button` : simplify use of prefix and suffix icons
 
 ### Removed
 

--- a/docs/components/six-button.md
+++ b/docs/components/six-button.md
@@ -162,55 +162,54 @@ Use the `prefix` and `suffix` slots to add icons.
 
 ```html
 <six-button size="small">
-  
-  <span slot="prefix"><six-icon size="xSmall">settings</six-icon></span>
+  <six-icon slot="prefix">settings</six-icon>
   Settings
 </six-button>
 
 <six-button size="small">
-  <span slot="suffix"><six-icon size="xSmall">refresh</six-icon></span>
+  <six-icon slot="suffix">refresh</six-icon>
   Refresh
 </six-button>
 
 <six-button size="small">
-  <span slot="prefix"><six-icon size="xSmall">settings</six-icon></span>
-  <span slot="suffix"><six-icon size="xSmall">refresh</six-icon></span>
+  <six-icon slot="prefix">settings</six-icon>
+  <six-icon slot="suffix">settings</six-icon>
   Open
 </six-button>
 
 <br><br>
 
 <six-button>
-  <span slot="prefix"><six-icon size="small">settings</six-icon></span>
+  <six-icon slot="prefix">settings</six-icon>
   Settings
 </six-button>
 
 <six-button>
-  <span slot="suffix"><six-icon size="small">refresh</six-icon></span>
+  <six-icon slot="suffix">refresh</six-icon>
   Refresh
 </six-button>
 
 <six-button>
-  <span slot="prefix"><six-icon size="small">settings</six-icon></span>
-  <span slot="suffix"><six-icon size="small">refresh</six-icon></span>
+  <six-icon slot="prefix">settings</six-icon>
+  <six-icon slot="suffix">refresh</six-icon>
   Open
 </six-button>
 
 <br><br>
 
 <six-button size="large">
-  <span slot="prefix"><six-icon size="medium">settings</six-icon></span>
+  <six-icon slot="prefix">settings</six-icon>
   Settings
 </six-button>
 
 <six-button size="large">
-  <span slot="suffix"><six-icon size="medium">refresh</six-icon></span>
+  <six-icon slot="suffix">refresh</six-icon>
   Refresh
 </six-button>
 
 <six-button size="large">
-  <span slot="prefix"><six-icon size="medium">settings</six-icon></span>
-  <span slot="suffix"><six-icon size="medium">refresh</six-icon></span>
+  <six-icon slot="prefix">settings</six-icon>
+  <six-icon slot="suffix">refresh</six-icon>
   Open
 </six-button>
 ```

--- a/docs/examples/docs-demo-six-button-9.vue
+++ b/docs/examples/docs-demo-six-button-9.vue
@@ -2,55 +2,54 @@
 <div>
 
         <six-button size="small">
-          
-          <span slot="prefix"><six-icon size="xSmall">settings</six-icon></span>
+          <six-icon slot="prefix">settings</six-icon>
           Settings
         </six-button>
 
         <six-button size="small">
-          <span slot="suffix"><six-icon size="xSmall">refresh</six-icon></span>
+          <six-icon slot="suffix">refresh</six-icon>
           Refresh
         </six-button>
 
         <six-button size="small">
-          <span slot="prefix"><six-icon size="xSmall">settings</six-icon></span>
-          <span slot="suffix"><six-icon size="xSmall">refresh</six-icon></span>
+          <six-icon slot="prefix">settings</six-icon>
+          <six-icon slot="suffix">settings</six-icon>
           Open
         </six-button>
 
         <br><br>
 
         <six-button>
-          <span slot="prefix"><six-icon size="small">settings</six-icon></span>
+          <six-icon slot="prefix">settings</six-icon>
           Settings
         </six-button>
 
         <six-button>
-          <span slot="suffix"><six-icon size="small">refresh</six-icon></span>
+          <six-icon slot="suffix">refresh</six-icon>
           Refresh
         </six-button>
 
         <six-button>
-          <span slot="prefix"><six-icon size="small">settings</six-icon></span>
-          <span slot="suffix"><six-icon size="small">refresh</six-icon></span>
+          <six-icon slot="prefix">settings</six-icon>
+          <six-icon slot="suffix">refresh</six-icon>
           Open
         </six-button>
 
         <br><br>
 
         <six-button size="large">
-          <span slot="prefix"><six-icon size="medium">settings</six-icon></span>
+          <six-icon slot="prefix">settings</six-icon>
           Settings
         </six-button>
 
         <six-button size="large">
-          <span slot="suffix"><six-icon size="medium">refresh</six-icon></span>
+          <six-icon slot="suffix">refresh</six-icon>
           Refresh
         </six-button>
 
         <six-button size="large">
-          <span slot="prefix"><six-icon size="medium">settings</six-icon></span>
-          <span slot="suffix"><six-icon size="medium">refresh</six-icon></span>
+          <six-icon slot="prefix">settings</six-icon>
+          <six-icon slot="suffix">refresh</six-icon>
           Open
         </six-button>
       

--- a/docs/guide/upgrade-v5.md
+++ b/docs/guide/upgrade-v5.md
@@ -75,6 +75,29 @@ in the Angular example application, which covers most features.
 </six-header>
 ```
 
+## Simpler use of components (None Breaking Change)
+
+- The prefix and suffix icons in the `six-button` component do not have to be wrapped in a span
+  anymore and the icon size will adapt based on the size of the button component.
+
+### Before
+
+```html
+<six-button>
+  <span slot="prefix"><six-icon size="small">settings</six-icon></span>
+  Setting
+</six-button>
+```
+
+### After
+
+```html
+<six-button>
+  <six-icon slot="prefix">settings</six-icon>
+  Setting
+</six-button>
+```
+
 ## Removed deprecated features (Breaking Change)
 
 Refer to the _Removed_ section in the [changelog](../changelog.md).

--- a/libraries/ui-library/src/components/six-button/index.html
+++ b/libraries/ui-library/src/components/six-button/index.html
@@ -137,55 +137,54 @@
       <p>Use the <code>prefix</code> and <code>suffix</code> slots to add icons.</p>
       <section>
         <six-button size="small">
-          <!-- <six-icon slot="prefix">settings</six-icon>-->
-          <span slot="prefix"><six-icon size="xSmall">settings</six-icon></span>
+          <six-icon slot="prefix">settings</six-icon>
           Settings
         </six-button>
 
         <six-button size="small">
-          <span slot="suffix"><six-icon size="xSmall">refresh</six-icon></span>
+          <six-icon slot="suffix">refresh</six-icon>
           Refresh
         </six-button>
 
         <six-button size="small">
-          <span slot="prefix"><six-icon size="xSmall">settings</six-icon></span>
-          <span slot="suffix"><six-icon size="xSmall">refresh</six-icon></span>
+          <six-icon slot="prefix">settings</six-icon>
+          <six-icon slot="suffix">settings</six-icon>
           Open
         </six-button>
 
         <br /><br />
 
         <six-button>
-          <span slot="prefix"><six-icon size="small">settings</six-icon></span>
+          <six-icon slot="prefix">settings</six-icon>
           Settings
         </six-button>
 
         <six-button>
-          <span slot="suffix"><six-icon size="small">refresh</six-icon></span>
+          <six-icon slot="suffix">refresh</six-icon>
           Refresh
         </six-button>
 
         <six-button>
-          <span slot="prefix"><six-icon size="small">settings</six-icon></span>
-          <span slot="suffix"><six-icon size="small">refresh</six-icon></span>
+          <six-icon slot="prefix">settings</six-icon>
+          <six-icon slot="suffix">refresh</six-icon>
           Open
         </six-button>
 
         <br /><br />
 
         <six-button size="large">
-          <span slot="prefix"><six-icon size="medium">settings</six-icon></span>
+          <six-icon slot="prefix">settings</six-icon>
           Settings
         </six-button>
 
         <six-button size="large">
-          <span slot="suffix"><six-icon size="medium">refresh</six-icon></span>
+          <six-icon slot="suffix">refresh</six-icon>
           Refresh
         </six-button>
 
         <six-button size="large">
-          <span slot="prefix"><six-icon size="medium">settings</six-icon></span>
-          <span slot="suffix"><six-icon size="medium">refresh</six-icon></span>
+          <six-icon slot="prefix">settings</six-icon>
+          <six-icon slot="suffix">refresh</six-icon>
           Open
         </six-button>
       </section>

--- a/libraries/ui-library/src/components/six-button/six-button.scss
+++ b/libraries/ui-library/src/components/six-button/six-button.scss
@@ -40,7 +40,9 @@
   ::slotted(six-icon) {
     // Clicks on icons shouldn't prevent the button from gaining focus
     pointer-events: none;
-    transform: translateY(-1.5px);
+    flex: 0 0 auto;
+    display: flex;
+    align-items: center;
   }
 }
 

--- a/libraries/ui-library/src/components/six-button/six-button.tsx
+++ b/libraries/ui-library/src/components/six-button/six-button.tsx
@@ -111,7 +111,28 @@ export class SixButton {
     this.hasLabel = hasSlot(this.host);
     this.hasPrefix = hasSlot(this.host, 'prefix');
     this.hasSuffix = hasSlot(this.host, 'suffix');
+
+    // set the correct icon size for suffix and prefix icons
+    const prefixIcon = this.host.querySelector('[slot="prefix"]');
+    const suffixIcon = this.host.querySelector('[slot="suffix"]');
+
+    if (prefixIcon?.tagName.toLowerCase() === 'six-icon') {
+      prefixIcon.setAttribute('size', this.mapSizeToIconSize(this.size));
+    }
+
+    if (suffixIcon?.tagName.toLowerCase() === 'six-icon') {
+      suffixIcon.setAttribute('size', this.mapSizeToIconSize(this.size));
+    }
   };
+
+  private mapSizeToIconSize(buttonSize: 'small' | 'medium' | 'large'): string {
+    const sizeMap = {
+      small: 'xSmall',
+      medium: 'small',
+      large: 'medium',
+    };
+    return sizeMap[buttonSize] || 'small'; // Default to small
+  }
 
   private handleBlur = () => {
     this.hasFocus = false;

--- a/libraries/ui-library/src/components/six-file-upload/six-file-upload.scss
+++ b/libraries/ui-library/src/components/six-file-upload/six-file-upload.scss
@@ -29,10 +29,6 @@ $margin: 1rem;
     }
   }
 
-  &__label-icon {
-    margin-right: 0.5rem;
-  }
-
   &__drop-zone {
     padding: 2rem 0;
     display: flex;

--- a/libraries/ui-library/src/components/six-file-upload/six-file-upload.tsx
+++ b/libraries/ui-library/src/components/six-file-upload/six-file-upload.tsx
@@ -212,11 +212,7 @@ export class SixFileUpload {
             'six-file-upload__container--full': !this.compact,
           }}
         >
-          {this.compact && !this.uploading && (
-            <span slot="prefix">
-              <six-icon class="six-file-upload__label-icon">arrow_circle_up</six-icon>
-            </span>
-          )}
+          {this.compact && !this.uploading && <six-icon slot="prefix">arrow_circle_up</six-icon>}
           <div
             class={{
               'six-file-upload__drop-zone': true,

--- a/libraries/ui-library/src/components/six-file-upload/test/six-file-upload.spec.tsx
+++ b/libraries/ui-library/src/components/six-file-upload/test/six-file-upload.spec.tsx
@@ -101,11 +101,9 @@ describe('six-file-upload', () => {
         <six-file-upload compact="">
           <div class="six-file-upload">
             <six-button aria-invalid="false" class="six-file-upload__container--compact">
-              <span slot="prefix">
-                <six-icon class="six-file-upload__label-icon">
+             <six-icon slot="prefix">
                   arrow_circle_up
                 </six-icon>
-              </span>
               <div class="six-file-upload__drop-zone six-file-upload__drop-zone--compact">
                 <div>
                   <span>
@@ -131,11 +129,9 @@ describe('six-file-upload', () => {
         <six-file-upload compact="" disabled="">
           <div class="six-file-upload six-file-upload--disabled">
             <six-button aria-invalid="false" class="six-file-upload__container--compact" disabled="">
-              <span slot="prefix">
-                <six-icon class="six-file-upload__label-icon">
+              <six-icon slot="prefix">
                   arrow_circle_up
                 </six-icon>
-              </span>
               <div class="six-file-upload__drop-zone six-file-upload__drop-zone--compact">
                 <div>
                   <span>


### PR DESCRIPTION

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

A small change in the six-button styling sheet such that the use of prefix and suffix icons does't require a wrapping span tag. This leads to cleaner code when using the component.

### 📝 Checklist


- [ ] I have linked an issue or discussion.
- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] I have updated the documentation accordingly.
- [x] All tests are passing
- [ ] New/updated tests are included
- [x] I have updated the "upcoming" section inside _docs/changelog.md_ explaining the changes I contributed

