### PR TITLE
docs: remove not existing property from documentation of six-icon-button

### DIFF
--- a/docs/components/six-icon-button.md
+++ b/docs/components/six-icon-button.md
@@ -6,8 +6,8 @@ Icons buttons are simple, icon-only buttons that can be used for actions and in 
 <docs-demo-six-icon-button-0></docs-demo-six-icon-button-0>
 
 ```html
-<six-icon-button name="settings" label="Settings" text-left="Settings"></six-icon-button>
-<six-icon-button name="tune" label="Options" text-left="Options"></six-icon-button>
+<six-icon-button name="settings" label="Settings"></six-icon-button>
+<six-icon-button name="tune" label="Options"></six-icon-button>
 <six-icon-button name="cancel" label="Close"></six-icon-button>
 ```
 

--- a/docs/examples/docs-demo-six-icon-button-0.vue
+++ b/docs/examples/docs-demo-six-icon-button-0.vue
@@ -1,8 +1,8 @@
 <template>
 <div>
 
-        <six-icon-button name="settings" label="Settings" text-left="Settings"></six-icon-button>
-        <six-icon-button name="tune" label="Options" text-left="Options"></six-icon-button>
+        <six-icon-button name="settings" label="Settings"></six-icon-button>
+        <six-icon-button name="tune" label="Options"></six-icon-button>
         <six-icon-button name="cancel" label="Close"></six-icon-button>
       
 </div>

--- a/libraries/ui-library/src/components/six-icon-button/index.html
+++ b/libraries/ui-library/src/components/six-icon-button/index.html
@@ -11,8 +11,8 @@
   <body>
     <div class="container">
       <section>
-        <six-icon-button name="settings" label="Settings" text-left="Settings"></six-icon-button>
-        <six-icon-button name="tune" label="Options" text-left="Options"></six-icon-button>
+        <six-icon-button name="settings" label="Settings"></six-icon-button>
+        <six-icon-button name="tune" label="Options"></six-icon-button>
         <six-icon-button name="cancel" label="Close"></six-icon-button>
       </section>
 


### PR DESCRIPTION


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/six-group/six-webcomponents/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Removed property `text-left` which is not supported or implemented by six-icon-button

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] It's submitted to the `main` branch
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] I have updated the documentation accordingly.
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] I have updated the "upcoming" section inside _docs/changelog.md_ explaining the changes I contributed

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
