### PR TITLE
feat: six-menu-items suffix/prefix can be used in six-select

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `six-header-menu-button`: Added `caret`, `disabled`, `loading`, `submit` and `reset` properties.
 - `six-header-menu-button`: Added `suffix` and `prefix` slots.
 - `six-sidebar-item` : added icon property analog to `six-sidebar-item-group`
+- `six-select` : support the use of prefix/suffix slot of the `six-menu-item` which can be used as
+  links for example.
 
 ### Fixed
 

--- a/docs/components/six-select.md
+++ b/docs/components/six-select.md
@@ -142,7 +142,50 @@ To allow multiple options to be selected, use the `multiple` attribute. It's a g
   <six-menu-item value="option-3">Option 3</six-menu-item>
   <six-menu-item value="option-4">Option 4</six-menu-item>
   <six-menu-item value="option-5">Option 5</six-menu-item>
-  <six-menu-item value="option-6">Option 6 (with tooltip due to long text)</six-menu-item>
+  <six-menu-item value="option-6">Option 6 (with tooltip due to long long long long text)</six-menu-item>
+</six-select>
+```
+
+
+### Multiple with Links
+
+With the prefix and suffix slots you can add links to the menu items. This is useful for adding actions to the menu items.
+
+.demo-multiple-icons six-menu-item::part(base) { display: flex; align-items: center; }
+
+<docs-demo-six-select-9></docs-demo-six-select-9>
+
+```html
+<six-select filter placeholder="Select a few" multiple clearable>
+  <six-menu-item value="option-1"
+    >Option 1
+    <six-icon-button               size="small"
+      slot="suffix"
+      target="_blank"
+      href="#"
+      name="favorite"
+      onclick="event.stopPropagation()"
+    ></six-icon-button>
+  </six-menu-item>
+  <six-menu-item value="option-2"
+    >Option 2
+    <six-icon-button               size="small"
+      slot="suffix"
+      target="_blank"
+      href="#"
+      name="favorite"
+      onclick="event.stopPropagation()"
+    ></six-icon-button></six-menu-item>
+  <six-menu-item value="option-3"
+    >Option 3
+    <six-icon-button               size="small"
+      slot="suffix"
+      target="_blank"
+      href="#"
+      name="favorite"
+      onclick="event.stopPropagation()"
+    ></six-icon-button>
+  </six-menu-item>
 </six-select>
 ```
 
@@ -151,7 +194,7 @@ To allow multiple options to be selected, use the `multiple` attribute. It's a g
 
 Options can be grouped visually using menu labels and menu dividers.
 
-<docs-demo-six-select-9></docs-demo-six-select-9>
+<docs-demo-six-select-10></docs-demo-six-select-10>
 
 ```html
 <six-select placeholder="Select one">
@@ -172,7 +215,7 @@ Options can be grouped visually using menu labels and menu dividers.
 
 Use the `size` attribute to change a select's size.
 
-<docs-demo-six-select-10></docs-demo-six-select-10>
+<docs-demo-six-select-11></docs-demo-six-select-11>
 
 ```html
 <six-select placeholder="Small" size="small" multiple>
@@ -203,7 +246,7 @@ Use the `size` attribute to change a select's size.
 
 The `value` prop is bound to the current selection. As the selection changes, so will the value. To programmatically manage the selection, update the value property.
 
-<docs-demo-six-select-11></docs-demo-six-select-11>
+<docs-demo-six-select-12></docs-demo-six-select-12>
 
 ```html
 <div class="selecting-example">
@@ -239,7 +282,7 @@ The `value` prop is bound to the current selection. As the selection changes, so
 
 Use the `label` attribute to give the select an accessible label. For labels that contain HTML, use the `label` slot instead.
 
-<docs-demo-six-select-12></docs-demo-six-select-12>
+<docs-demo-six-select-13></docs-demo-six-select-13>
 
 ```html
 <six-select label="Select one">
@@ -254,7 +297,7 @@ Use the `label` attribute to give the select an accessible label. For labels tha
 
 Add descriptive help text to a select with the `help-text` attribute. For help texts that contain HTML, use the help-text slot instead.
 
-<docs-demo-six-select-13></docs-demo-six-select-13>
+<docs-demo-six-select-14></docs-demo-six-select-14>
 
 ```html
 <six-select label="Experience" help-text="Please tell us your skill level.">
@@ -269,7 +312,7 @@ Add descriptive help text to a select with the `help-text` attribute. For help t
 
 Dropdown panels will be clipped if they're inside a container that has overflow: auto|hidden. The hoist attribute forces the panel to use a fixed positioning strategy, allowing it to break out of the container. In this case, the panel will be positioned relative to its containing block, which is usually the viewport unless an ancestor uses a transform, perspective, or filter.
 
-<docs-demo-six-select-14></docs-demo-six-select-14>
+<docs-demo-six-select-15></docs-demo-six-select-15>
 
 ```html
 <div style="overflow: hidden; border: solid 1px grey; padding: 0.5em; display: flex">
@@ -292,7 +335,7 @@ Dropdown panels will be clipped if they're inside a container that has overflow:
 
 There was a bug where hoisting inside drawers caused a problem
 
-<docs-demo-six-select-15></docs-demo-six-select-15>
+<docs-demo-six-select-16></docs-demo-six-select-16>
 
 ```html
 <six-button id="hoistingDrawerBtn">Open Drawer</six-button>
@@ -355,7 +398,7 @@ You can filter the items shown by simply adding `filter="true"` to six-select
 
 You can also pass a custom placeholder with `filter-placeholder` to be shown in the filter input field (will be 'Filter...' by default)
 
-<docs-demo-six-select-16></docs-demo-six-select-16>
+<docs-demo-six-select-17></docs-demo-six-select-17>
 
 ```html
 <six-select label="Experience" filter multiple select-all-button clearable>
@@ -381,7 +424,7 @@ In such a scenario simply add the `async-filter` attribute to your dropdown comp
 
 If you want to change the default debounce timeout use e.g. `filter-debounce="500"`
 
-<docs-demo-six-select-17></docs-demo-six-select-17>
+<docs-demo-six-select-18></docs-demo-six-select-18>
 
 ```html
 <six-select id="async-select" async-filter filter-placeholder="Enter a number">
@@ -429,7 +472,7 @@ If you want to change the default debounce timeout use e.g. `filter-debounce="50
 
 If you have huge amounts of data you want to present in the dropdown you can't render all at once or it will crash your browser. For these usescases listen to the scroll event to decide which data to present.
 
-<docs-demo-six-select-18></docs-demo-six-select-18>
+<docs-demo-six-select-19></docs-demo-six-select-19>
 
 ```html
 <six-select id="infinite-scoll-dropdown">
@@ -475,7 +518,7 @@ Autocomplete does currently not support multiselect!
 
 You can adjust the debounce timeout via the `input-debounce` attribute
 
-<docs-demo-six-select-19></docs-demo-six-select-19>
+<docs-demo-six-select-20></docs-demo-six-select-20>
 
 ```html
 <six-select id="autocomplete-example" autocomplete clearable></six-select>
@@ -519,7 +562,7 @@ You can adjust the debounce timeout via the `input-debounce` attribute
 
 If you don't want to create a `six-menu-item` but simply want to pass an array with all options, you can do so via the `options` attribute.
 
-<docs-demo-six-select-20></docs-demo-six-select-20>
+<docs-demo-six-select-21></docs-demo-six-select-21>
 
 ```html
 <six-select filter multiple id="six-select-dynamic-options"></six-select>
@@ -537,7 +580,7 @@ If you don't want to create a `six-menu-item` but simply want to pass an array w
 
 If you have a lot of items in the menu (100'000 in the following example), rendering all of them might lead to some performance issues. To avoid such issues use `virtual-scroll`
 
-<docs-demo-six-select-21></docs-demo-six-select-21>
+<docs-demo-six-select-22></docs-demo-six-select-22>
 
 ```html
 <six-select id="six-select-virtual-scroll" virtual-scroll></six-select>
@@ -555,7 +598,7 @@ If you have a lot of items in the menu (100'000 in the following example), rende
 
 In the following example you see the combination of `autocomplete` with `virtual-scroll`. The list contains 10'000 entries. Enter a number in the input field and you can virtually scroll through all elements which contain this number.
 
-<docs-demo-six-select-22></docs-demo-six-select-22>
+<docs-demo-six-select-23></docs-demo-six-select-23>
 
 ```html
 <six-select id="virtual-autocomplete-example" autocomplete clearable virtual-scroll></six-select>
@@ -604,14 +647,14 @@ warning There are two caveats when using the `error-text` prop/slot:
 
 The `error-text` prop accepts either a simple string message, or a list of messages.
 
-<docs-demo-six-select-23></docs-demo-six-select-23>
+<docs-demo-six-select-24></docs-demo-six-select-24>
 
 ```html
 <six-select label="Simple string message" error-text="This is a simple string message" invalid> </six-select>
 ```
 
 
-<docs-demo-six-select-24></docs-demo-six-select-24>
+<docs-demo-six-select-25></docs-demo-six-select-25>
 
 ```html
 <six-select id="multiple-error-text" label="List of string message" invalid></six-select>
@@ -625,7 +668,7 @@ The `error-text` prop accepts either a simple string message, or a list of messa
 
 When using the `error-text` slot, it is recommended to use the `six-error` component to wrap the error message(s). This will provide the correct styling out of the box
 
-<docs-demo-six-select-25></docs-demo-six-select-25>
+<docs-demo-six-select-26></docs-demo-six-select-26>
 
 ```html
 <six-select invalid>

--- a/docs/examples/docs-demo-six-select-10.vue
+++ b/docs/examples/docs-demo-six-select-10.vue
@@ -1,26 +1,16 @@
 <template>
 <div>
 
-        <six-select placeholder="Small" size="small" multiple>
+        <six-select placeholder="Select one">
+          <six-menu-label>Group 1</six-menu-label>
           <six-menu-item value="option-1">Option 1</six-menu-item>
           <six-menu-item value="option-2">Option 2</six-menu-item>
           <six-menu-item value="option-3">Option 3</six-menu-item>
-        </six-select>
-
-        <br>
-
-        <six-select placeholder="Medium" size="medium" multiple>
-          <six-menu-item value="option-1">Option 1</six-menu-item>
-          <six-menu-item value="option-2">Option 2</six-menu-item>
-          <six-menu-item value="option-3">Option 3</six-menu-item>
-        </six-select>
-
-        <br>
-
-        <six-select placeholder="Large" size="large" multiple>
-          <six-menu-item value="option-1">Option 1</six-menu-item>
-          <six-menu-item value="option-2">Option 2</six-menu-item>
-          <six-menu-item value="option-3">Option 3</six-menu-item>
+          <six-menu-divider></six-menu-divider>
+          <six-menu-label>Group 2</six-menu-label>
+          <six-menu-item value="option-4">Option 4</six-menu-item>
+          <six-menu-item value="option-5">Option 5</six-menu-item>
+          <six-menu-item value="option-6">Option 6</six-menu-item>
         </six-select>
       
 </div>

--- a/docs/examples/docs-demo-six-select-11.vue
+++ b/docs/examples/docs-demo-six-select-11.vue
@@ -1,21 +1,27 @@
 <template>
 <div>
 
-        <div class="selecting-example">
-          <six-select placeholder="">
-            <six-menu-item value="option-1">Option 1</six-menu-item>
-            <six-menu-item value="option-2">Option 2</six-menu-item>
-            <six-menu-item value="option-3">Option 3</six-menu-item>
-          </six-select>
+        <six-select placeholder="Small" size="small" multiple>
+          <six-menu-item value="option-1">Option 1</six-menu-item>
+          <six-menu-item value="option-2">Option 2</six-menu-item>
+          <six-menu-item value="option-3">Option 3</six-menu-item>
+        </six-select>
 
-          <br>
+        <br>
 
-          <six-button data-option="option-1">Set 1</six-button>
-          <six-button data-option="option-2">Set 2</six-button>
-          <six-button data-option="option-3">Set 3</six-button>
-        </div>
+        <six-select placeholder="Medium" size="medium" multiple>
+          <six-menu-item value="option-1">Option 1</six-menu-item>
+          <six-menu-item value="option-2">Option 2</six-menu-item>
+          <six-menu-item value="option-3">Option 3</six-menu-item>
+        </six-select>
 
-        
+        <br>
+
+        <six-select placeholder="Large" size="large" multiple>
+          <six-menu-item value="option-1">Option 1</six-menu-item>
+          <six-menu-item value="option-2">Option 2</six-menu-item>
+          <six-menu-item value="option-3">Option 3</six-menu-item>
+        </six-select>
       
 </div>
 </template>
@@ -25,17 +31,6 @@
 <script>
 export default {
   name: 'docs-demo-six-select-11',
-  mounted() { 
-          (() => {
-            const container = document.querySelector('.selecting-example');
-            const select = container.querySelector('six-select');
-
-            [...container.querySelectorAll('six-button')].map((button) => {
-              button.addEventListener('click', () => {
-                select.value = button.dataset.option;
-              });
-            });
-          })();
-         }
+  mounted() {  }
 }
 </script>

--- a/docs/examples/docs-demo-six-select-12.vue
+++ b/docs/examples/docs-demo-six-select-12.vue
@@ -1,11 +1,21 @@
 <template>
 <div>
 
-        <six-select label="Select one">
-          <six-menu-item value="option-1">Option 1</six-menu-item>
-          <six-menu-item value="option-2">Option 2</six-menu-item>
-          <six-menu-item value="option-3">Option 3</six-menu-item>
-        </six-select>
+        <div class="selecting-example">
+          <six-select placeholder="">
+            <six-menu-item value="option-1">Option 1</six-menu-item>
+            <six-menu-item value="option-2">Option 2</six-menu-item>
+            <six-menu-item value="option-3">Option 3</six-menu-item>
+          </six-select>
+
+          <br>
+
+          <six-button data-option="option-1">Set 1</six-button>
+          <six-button data-option="option-2">Set 2</six-button>
+          <six-button data-option="option-3">Set 3</six-button>
+        </div>
+
+        
       
 </div>
 </template>
@@ -15,6 +25,17 @@
 <script>
 export default {
   name: 'docs-demo-six-select-12',
-  mounted() {  }
+  mounted() { 
+          (() => {
+            const container = document.querySelector('.selecting-example');
+            const select = container.querySelector('six-select');
+
+            [...container.querySelectorAll('six-button')].map((button) => {
+              button.addEventListener('click', () => {
+                select.value = button.dataset.option;
+              });
+            });
+          })();
+         }
 }
 </script>

--- a/docs/examples/docs-demo-six-select-13.vue
+++ b/docs/examples/docs-demo-six-select-13.vue
@@ -1,10 +1,10 @@
 <template>
 <div>
 
-        <six-select label="Experience" help-text="Please tell us your skill level.">
-          <six-menu-item value="option-1">Novice</six-menu-item>
-          <six-menu-item value="option-2">Intermediate</six-menu-item>
-          <six-menu-item value="option-3">Advanced</six-menu-item>
+        <six-select label="Select one">
+          <six-menu-item value="option-1">Option 1</six-menu-item>
+          <six-menu-item value="option-2">Option 2</six-menu-item>
+          <six-menu-item value="option-3">Option 3</six-menu-item>
         </six-select>
       
 </div>

--- a/docs/examples/docs-demo-six-select-14.vue
+++ b/docs/examples/docs-demo-six-select-14.vue
@@ -1,19 +1,11 @@
 <template>
 <div>
 
-        <div style="overflow: hidden; border: solid 1px grey; padding: 0.5em; display: flex">
-          <six-select placeholder="No Hoisting" style="width: 10em">
-            <six-menu-item value="option-1">Novice</six-menu-item>
-            <six-menu-item value="option-2">Intermediate</six-menu-item>
-            <six-menu-item value="option-3">Advanced</six-menu-item>
-          </six-select>
-
-          <six-select placeholder="Hoisting" filter="true" hoist style="width: 10em">
-            <six-menu-item value="option-1">Novice</six-menu-item>
-            <six-menu-item value="option-2">Intermediate</six-menu-item>
-            <six-menu-item value="option-3">Advanced</six-menu-item>
-          </six-select>
-        </div>
+        <six-select label="Experience" help-text="Please tell us your skill level.">
+          <six-menu-item value="option-1">Novice</six-menu-item>
+          <six-menu-item value="option-2">Intermediate</six-menu-item>
+          <six-menu-item value="option-3">Advanced</six-menu-item>
+        </six-select>
       
 </div>
 </template>

--- a/docs/examples/docs-demo-six-select-15.vue
+++ b/docs/examples/docs-demo-six-select-15.vue
@@ -1,53 +1,19 @@
 <template>
 <div>
 
-        <six-button id="hoistingDrawerBtn">Open Drawer</six-button>
-        <six-drawer id="hoistingDrawer" label="Drawer" class="drawer-overview">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          <six-button slot="footer">Close</six-button>
-          <div class="demo" style="width: 300px">
-            <six-tooltip content="something">
-              <div>some tooltip</div>
-            </six-tooltip>
-            <div style="overflow: hidden; border: solid 1px grey; padding: 0.5em; display: flex">
-              <six-select placeholder="No Hoisting" style="width: 10em">
-                <six-tooltip content="something">
-                  <six-menu-item value="option-1">Novice</six-menu-item>
-                </six-tooltip>
-                <six-menu-item value="option-2">Intermediate</six-menu-item>
-                <six-menu-item value="option-3">Advanced</six-menu-item>
-              </six-select>
+        <div style="overflow: hidden; border: solid 1px grey; padding: 0.5em; display: flex">
+          <six-select placeholder="No Hoisting" style="width: 10em">
+            <six-menu-item value="option-1">Novice</six-menu-item>
+            <six-menu-item value="option-2">Intermediate</six-menu-item>
+            <six-menu-item value="option-3">Advanced</six-menu-item>
+          </six-select>
 
-              <six-select placeholder="Hoisting" hoist style="width: 10em">
-                <six-menu-item value="option-1">Novice</six-menu-item>
-                <six-menu-item value="option-2">Intermediate</six-menu-item>
-                <six-menu-item value="option-3">Advanced</six-menu-item>
-              </six-select>
-            </div>
-
-            <div style="overflow: hidden; border: solid 1px grey; padding: 0.5em; display: flex">
-              <six-dropdown>
-                <six-button slot="trigger" caret>No Hoist</six-button>
-                <six-menu>
-                  <six-menu-item>Item 1</six-menu-item>
-                  <six-menu-item>Item 2</six-menu-item>
-                  <six-menu-item>Item 3</six-menu-item>
-                </six-menu>
-              </six-dropdown>
-
-              <six-dropdown hoist>
-                <six-button slot="trigger" caret>Hoist</six-button>
-                <six-menu>
-                  <six-menu-item>Item 1</six-menu-item>
-                  <six-menu-item>Item 2</six-menu-item>
-                  <six-menu-item>Item 3</six-menu-item>
-                </six-menu>
-              </six-dropdown>
-            </div>
-          </div>
-        </six-drawer>
-
-        
+          <six-select placeholder="Hoisting" filter="true" hoist style="width: 10em">
+            <six-menu-item value="option-1">Novice</six-menu-item>
+            <six-menu-item value="option-2">Intermediate</six-menu-item>
+            <six-menu-item value="option-3">Advanced</six-menu-item>
+          </six-select>
+        </div>
       
 </div>
 </template>
@@ -57,10 +23,6 @@
 <script>
 export default {
   name: 'docs-demo-six-select-15',
-  mounted() { 
-          const sixDrawerBtn = document.querySelector('#hoistingDrawerBtn');
-          const sixDrawer = document.querySelector('#hoistingDrawer');
-          sixDrawerBtn.addEventListener('click', () => (sixDrawer.open = true));
-         }
+  mounted() {  }
 }
 </script>

--- a/docs/examples/docs-demo-six-select-16.vue
+++ b/docs/examples/docs-demo-six-select-16.vue
@@ -1,18 +1,53 @@
 <template>
 <div>
 
-        <six-select label="Experience" filter multiple select-all-button clearable>
-          <six-menu-item value="AUSTRALIA">Australia</six-menu-item>
-          <six-menu-item value="BRAZIL">Brazil</six-menu-item>
-          <six-menu-item value="CHINA">China</six-menu-item>
-          <six-menu-item value="EGYPT">Egypt</six-menu-item>
-          <six-menu-item value="FRANCE">France</six-menu-item>
-          <six-menu-item value="GERMANY">Germany</six-menu-item>
-          <six-menu-item value="INDIA">India</six-menu-item>
-          <six-menu-item value="JAPAN">Japan</six-menu-item>
-          <six-menu-item value="SPAIN">Spain</six-menu-item>
-          <six-menu-item value="UNITED_STATES">United States</six-menu-item>
-        </six-select>
+        <six-button id="hoistingDrawerBtn">Open Drawer</six-button>
+        <six-drawer id="hoistingDrawer" label="Drawer" class="drawer-overview">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+          <six-button slot="footer">Close</six-button>
+          <div class="demo" style="width: 300px">
+            <six-tooltip content="something">
+              <div>some tooltip</div>
+            </six-tooltip>
+            <div style="overflow: hidden; border: solid 1px grey; padding: 0.5em; display: flex">
+              <six-select placeholder="No Hoisting" style="width: 10em">
+                <six-tooltip content="something">
+                  <six-menu-item value="option-1">Novice</six-menu-item>
+                </six-tooltip>
+                <six-menu-item value="option-2">Intermediate</six-menu-item>
+                <six-menu-item value="option-3">Advanced</six-menu-item>
+              </six-select>
+
+              <six-select placeholder="Hoisting" hoist style="width: 10em">
+                <six-menu-item value="option-1">Novice</six-menu-item>
+                <six-menu-item value="option-2">Intermediate</six-menu-item>
+                <six-menu-item value="option-3">Advanced</six-menu-item>
+              </six-select>
+            </div>
+
+            <div style="overflow: hidden; border: solid 1px grey; padding: 0.5em; display: flex">
+              <six-dropdown>
+                <six-button slot="trigger" caret>No Hoist</six-button>
+                <six-menu>
+                  <six-menu-item>Item 1</six-menu-item>
+                  <six-menu-item>Item 2</six-menu-item>
+                  <six-menu-item>Item 3</six-menu-item>
+                </six-menu>
+              </six-dropdown>
+
+              <six-dropdown hoist>
+                <six-button slot="trigger" caret>Hoist</six-button>
+                <six-menu>
+                  <six-menu-item>Item 1</six-menu-item>
+                  <six-menu-item>Item 2</six-menu-item>
+                  <six-menu-item>Item 3</six-menu-item>
+                </six-menu>
+              </six-dropdown>
+            </div>
+          </div>
+        </six-drawer>
+
+        
       
 </div>
 </template>
@@ -22,6 +57,10 @@
 <script>
 export default {
   name: 'docs-demo-six-select-16',
-  mounted() {  }
+  mounted() { 
+          const sixDrawerBtn = document.querySelector('#hoistingDrawerBtn');
+          const sixDrawer = document.querySelector('#hoistingDrawer');
+          sixDrawerBtn.addEventListener('click', () => (sixDrawer.open = true));
+         }
 }
 </script>

--- a/docs/examples/docs-demo-six-select-17.vue
+++ b/docs/examples/docs-demo-six-select-17.vue
@@ -1,10 +1,18 @@
 <template>
 <div>
 
-        <six-select id="async-select" async-filter filter-placeholder="Enter a number">
-          <six-menu-item id="async-menu-item" value="search_list_prompt">Use search to show entries</six-menu-item>
+        <six-select label="Experience" filter multiple select-all-button clearable>
+          <six-menu-item value="AUSTRALIA">Australia</six-menu-item>
+          <six-menu-item value="BRAZIL">Brazil</six-menu-item>
+          <six-menu-item value="CHINA">China</six-menu-item>
+          <six-menu-item value="EGYPT">Egypt</six-menu-item>
+          <six-menu-item value="FRANCE">France</six-menu-item>
+          <six-menu-item value="GERMANY">Germany</six-menu-item>
+          <six-menu-item value="INDIA">India</six-menu-item>
+          <six-menu-item value="JAPAN">Japan</six-menu-item>
+          <six-menu-item value="SPAIN">Spain</six-menu-item>
+          <six-menu-item value="UNITED_STATES">United States</six-menu-item>
         </six-select>
-        
       
 </div>
 </template>
@@ -14,40 +22,6 @@
 <script>
 export default {
   name: 'docs-demo-six-select-17',
-  mounted() { 
-          const asyncSelect = document.querySelector('#async-select');
-          const asyncMenu = document.querySelector('#async-menu-item').parentElement;
-
-          for (let i = 0; i < 500; i++) {
-            const child = document.createElement('six-menu-item');
-            child.innerText = `Value ${i}`;
-            child.value = `value-${i}`;
-            asyncMenu.appendChild(child);
-          }
-
-          const removeAllChildNodes = (parent) => {
-            while (parent.firstChild) {
-              parent.removeChild(parent.firstChild);
-            }
-          };
-
-          asyncSelect.addEventListener('six-async-filter-fired', ($event) => {
-            const filterValue = $event.detail.filterValue;
-            removeAllChildNodes(asyncMenu);
-            for (let i = 0; i < 500; i++) {
-              const child = document.createElement('six-menu-item');
-              child.innerText = `Value ${i}`;
-              child.value = `value-${i}`;
-              if (
-                filterValue.includes(`${i}`) ||
-                filterValue.toLocaleLowerCase().includes(`value`) ||
-                filterValue.toLocaleLowerCase().includes(`value ${i}`) ||
-                filterValue === ''
-              ) {
-                asyncMenu.appendChild(child);
-              }
-            }
-          });
-         }
+  mounted() {  }
 }
 </script>

--- a/docs/examples/docs-demo-six-select-18.vue
+++ b/docs/examples/docs-demo-six-select-18.vue
@@ -1,8 +1,8 @@
 <template>
 <div>
 
-        <six-select id="infinite-scoll-dropdown">
-          <six-menu-item id="infinite-scroll-menu" value="search_list_prompt">Value 0</six-menu-item>
+        <six-select id="async-select" async-filter filter-placeholder="Enter a number">
+          <six-menu-item id="async-menu-item" value="search_list_prompt">Use search to show entries</six-menu-item>
         </six-select>
         
       
@@ -15,30 +15,36 @@
 export default {
   name: 'docs-demo-six-select-18',
   mounted() { 
-          const asyncSelect = document.querySelector('#infinite-scoll-dropdown');
-          const asyncMenu = document.querySelector('#infinite-scroll-menu').parentElement;
+          const asyncSelect = document.querySelector('#async-select');
+          const asyncMenu = document.querySelector('#async-menu-item').parentElement;
 
-          let id = 1;
-
-          for (let i = 0; i < 20; i++) {
+          for (let i = 0; i < 500; i++) {
             const child = document.createElement('six-menu-item');
-            child.innerText = `Value ${id}`;
-            child.value = `value-${id}`;
+            child.innerText = `Value ${i}`;
+            child.value = `value-${i}`;
             asyncMenu.appendChild(child);
-            id++;
           }
 
-          asyncSelect.addEventListener('six-dropdown-scroll', ($event) => {
-            const { scrollRatio } = $event.detail;
+          const removeAllChildNodes = (parent) => {
+            while (parent.firstChild) {
+              parent.removeChild(parent.firstChild);
+            }
+          };
 
-            // add new elements once we reach almost bottom
-            if (scrollRatio > 0.8) {
-              for (let i = 0; i < 20; i++) {
-                const child = document.createElement('six-menu-item');
-                child.innerText = `Value ${id}`;
-                child.value = `value-${id}`;
+          asyncSelect.addEventListener('six-async-filter-fired', ($event) => {
+            const filterValue = $event.detail.filterValue;
+            removeAllChildNodes(asyncMenu);
+            for (let i = 0; i < 500; i++) {
+              const child = document.createElement('six-menu-item');
+              child.innerText = `Value ${i}`;
+              child.value = `value-${i}`;
+              if (
+                filterValue.includes(`${i}`) ||
+                filterValue.toLocaleLowerCase().includes(`value`) ||
+                filterValue.toLocaleLowerCase().includes(`value ${i}`) ||
+                filterValue === ''
+              ) {
                 asyncMenu.appendChild(child);
-                id++;
               }
             }
           });

--- a/docs/examples/docs-demo-six-select-19.vue
+++ b/docs/examples/docs-demo-six-select-19.vue
@@ -1,7 +1,9 @@
 <template>
 <div>
 
-        <six-select id="autocomplete-example" autocomplete clearable></six-select>
+        <six-select id="infinite-scoll-dropdown">
+          <six-menu-item id="infinite-scroll-menu" value="search_list_prompt">Value 0</six-menu-item>
+        </six-select>
         
       
 </div>
@@ -13,37 +15,33 @@
 export default {
   name: 'docs-demo-six-select-19',
   mounted() { 
-          (() => {
-            const clearAllChildren = (node) => {
-              let child = node.lastElementChild;
-              while (child) {
-                node.removeChild(child);
-                child = node.lastElementChild;
+          const asyncSelect = document.querySelector('#infinite-scoll-dropdown');
+          const asyncMenu = document.querySelector('#infinite-scroll-menu').parentElement;
+
+          let id = 1;
+
+          for (let i = 0; i < 20; i++) {
+            const child = document.createElement('six-menu-item');
+            child.innerText = `Value ${id}`;
+            child.value = `value-${id}`;
+            asyncMenu.appendChild(child);
+            id++;
+          }
+
+          asyncSelect.addEventListener('six-dropdown-scroll', ($event) => {
+            const { scrollRatio } = $event.detail;
+
+            // add new elements once we reach almost bottom
+            if (scrollRatio > 0.8) {
+              for (let i = 0; i < 20; i++) {
+                const child = document.createElement('six-menu-item');
+                child.innerText = `Value ${id}`;
+                child.value = `value-${id}`;
+                asyncMenu.appendChild(child);
+                id++;
               }
-            };
-
-            const createMenuItem = (value, label) => {
-              const menuItem = document.createElement('six-menu-item');
-              menuItem.innerText = label;
-              menuItem.setAttribute('value', value);
-              return menuItem;
-            };
-
-            const select = document.getElementById('autocomplete-example');
-
-            select.addEventListener('six-select-change', (event) => {
-              if (event.detail.isSelected) {
-                // don't fetch new values on selection
-                return;
-              }
-              clearAllChildren(select);
-
-              const enteredText = event.detail.value || 'All Values';
-              new Array(5).fill('').forEach((item, idx) => {
-                select.append(createMenuItem(`option ${enteredText} ${idx}`, `Option ${enteredText} ${idx}`));
-              });
-            });
-          })();
+            }
+          });
          }
 }
 </script>

--- a/docs/examples/docs-demo-six-select-20.vue
+++ b/docs/examples/docs-demo-six-select-20.vue
@@ -1,7 +1,7 @@
 <template>
 <div>
 
-        <six-select filter multiple id="six-select-dynamic-options"></six-select>
+        <six-select id="autocomplete-example" autocomplete clearable></six-select>
         
       
 </div>
@@ -13,11 +13,37 @@
 export default {
   name: 'docs-demo-six-select-20',
   mounted() { 
-          const sixSelectDynamicOptions = document.getElementById('six-select-dynamic-options');
-          sixSelectDynamicOptions.options = Array.from(Array(100).keys()).map((idx) => ({
-            label: `label ${idx}`,
-            value: `value ${idx}`,
-          }));
+          (() => {
+            const clearAllChildren = (node) => {
+              let child = node.lastElementChild;
+              while (child) {
+                node.removeChild(child);
+                child = node.lastElementChild;
+              }
+            };
+
+            const createMenuItem = (value, label) => {
+              const menuItem = document.createElement('six-menu-item');
+              menuItem.innerText = label;
+              menuItem.setAttribute('value', value);
+              return menuItem;
+            };
+
+            const select = document.getElementById('autocomplete-example');
+
+            select.addEventListener('six-select-change', (event) => {
+              if (event.detail.isSelected) {
+                // don't fetch new values on selection
+                return;
+              }
+              clearAllChildren(select);
+
+              const enteredText = event.detail.value || 'All Values';
+              new Array(5).fill('').forEach((item, idx) => {
+                select.append(createMenuItem(`option ${enteredText} ${idx}`, `Option ${enteredText} ${idx}`));
+              });
+            });
+          })();
          }
 }
 </script>

--- a/docs/examples/docs-demo-six-select-21.vue
+++ b/docs/examples/docs-demo-six-select-21.vue
@@ -1,7 +1,7 @@
 <template>
 <div>
 
-        <six-select id="six-select-virtual-scroll" virtual-scroll></six-select>
+        <six-select filter multiple id="six-select-dynamic-options"></six-select>
         
       
 </div>
@@ -13,8 +13,8 @@
 export default {
   name: 'docs-demo-six-select-21',
   mounted() { 
-          const sixSelectDynamicOptions = document.getElementById('six-select-virtual-scroll');
-          sixSelectDynamicOptions.options = Array.from(Array(100000).keys()).map((idx) => ({
+          const sixSelectDynamicOptions = document.getElementById('six-select-dynamic-options');
+          sixSelectDynamicOptions.options = Array.from(Array(100).keys()).map((idx) => ({
             label: `label ${idx}`,
             value: `value ${idx}`,
           }));

--- a/docs/examples/docs-demo-six-select-22.vue
+++ b/docs/examples/docs-demo-six-select-22.vue
@@ -1,7 +1,7 @@
 <template>
 <div>
 
-        <six-select id="virtual-autocomplete-example" autocomplete clearable virtual-scroll></six-select>
+        <six-select id="six-select-virtual-scroll" virtual-scroll></six-select>
         
       
 </div>
@@ -13,35 +13,11 @@
 export default {
   name: 'docs-demo-six-select-22',
   mounted() { 
-          const virtualAutocomplete = document.getElementById('virtual-autocomplete-example');
-
-          // generate some options
-          const allOptions = Array.from(Array(10000).keys()).map((idx) => ({
+          const sixSelectDynamicOptions = document.getElementById('six-select-virtual-scroll');
+          sixSelectDynamicOptions.options = Array.from(Array(100000).keys()).map((idx) => ({
             label: `label ${idx}`,
             value: `value ${idx}`,
           }));
-
-          // assign the options to the six-select
-          virtualAutocomplete.options = allOptions;
-
-          // set up an eventlistener on change
-          virtualAutocomplete.addEventListener('six-select-change', (event) => {
-            if (event.detail.isSelected) {
-              // don't fetch new values on selection
-              return;
-            }
-
-            const enteredText = event.detail.value;
-            if (!enteredText) {
-              // if no text has been entered all options should be available
-              virtualAutocomplete.options = allOptions;
-            }
-
-            // otherwise if a text has been entered filter for all options which contain the entered text
-            virtualAutocomplete.options = allOptions.filter(
-              (option) => option.label.includes(enteredText) || option.value.includes(enteredText)
-            );
-          });
          }
 }
 </script>

--- a/docs/examples/docs-demo-six-select-23.vue
+++ b/docs/examples/docs-demo-six-select-23.vue
@@ -1,7 +1,8 @@
 <template>
 <div>
 
-        <six-select label="Simple string message" error-text="This is a simple string message" invalid> </six-select>
+        <six-select id="virtual-autocomplete-example" autocomplete clearable virtual-scroll></six-select>
+        
       
 </div>
 </template>
@@ -11,6 +12,36 @@
 <script>
 export default {
   name: 'docs-demo-six-select-23',
-  mounted() {  }
+  mounted() { 
+          const virtualAutocomplete = document.getElementById('virtual-autocomplete-example');
+
+          // generate some options
+          const allOptions = Array.from(Array(10000).keys()).map((idx) => ({
+            label: `label ${idx}`,
+            value: `value ${idx}`,
+          }));
+
+          // assign the options to the six-select
+          virtualAutocomplete.options = allOptions;
+
+          // set up an eventlistener on change
+          virtualAutocomplete.addEventListener('six-select-change', (event) => {
+            if (event.detail.isSelected) {
+              // don't fetch new values on selection
+              return;
+            }
+
+            const enteredText = event.detail.value;
+            if (!enteredText) {
+              // if no text has been entered all options should be available
+              virtualAutocomplete.options = allOptions;
+            }
+
+            // otherwise if a text has been entered filter for all options which contain the entered text
+            virtualAutocomplete.options = allOptions.filter(
+              (option) => option.label.includes(enteredText) || option.value.includes(enteredText)
+            );
+          });
+         }
 }
 </script>

--- a/docs/examples/docs-demo-six-select-24.vue
+++ b/docs/examples/docs-demo-six-select-24.vue
@@ -1,8 +1,7 @@
 <template>
 <div>
 
-        <six-select id="multiple-error-text" label="List of string message" invalid></six-select>
-        
+        <six-select label="Simple string message" error-text="This is a simple string message" invalid> </six-select>
       
 </div>
 </template>
@@ -12,10 +11,6 @@
 <script>
 export default {
   name: 'docs-demo-six-select-24',
-  mounted() { 
-          const sixSelect = document.getElementById('multiple-error-text');
-          sixSelect.errorText = ['Message 1', 'Message 2'];
-          sixSelect.errorTextCount = 3;
-         }
+  mounted() {  }
 }
 </script>

--- a/docs/examples/docs-demo-six-select-25.vue
+++ b/docs/examples/docs-demo-six-select-25.vue
@@ -1,12 +1,8 @@
 <template>
 <div>
 
-        <six-select invalid>
-          <div slot="error-text">
-            <six-error               >An error message
-              <a href="https://github.com/six-group/six-webcomponents" target="_blank">with a link</a></six-error>
-          </div>
-        </six-select>
+        <six-select id="multiple-error-text" label="List of string message" invalid></six-select>
+        
       
 </div>
 </template>
@@ -16,6 +12,10 @@
 <script>
 export default {
   name: 'docs-demo-six-select-25',
-  mounted() {  }
+  mounted() { 
+          const sixSelect = document.getElementById('multiple-error-text');
+          sixSelect.errorText = ['Message 1', 'Message 2'];
+          sixSelect.errorTextCount = 3;
+         }
 }
 </script>

--- a/docs/examples/docs-demo-six-select-8.vue
+++ b/docs/examples/docs-demo-six-select-8.vue
@@ -7,7 +7,7 @@
           <six-menu-item value="option-3">Option 3</six-menu-item>
           <six-menu-item value="option-4">Option 4</six-menu-item>
           <six-menu-item value="option-5">Option 5</six-menu-item>
-          <six-menu-item value="option-6">Option 6 (with tooltip due to long text)</six-menu-item>
+          <six-menu-item value="option-6">Option 6 (with tooltip due to long long long long text)</six-menu-item>
         </six-select>
       
 </div>

--- a/docs/examples/docs-demo-six-select-9.vue
+++ b/docs/examples/docs-demo-six-select-9.vue
@@ -1,16 +1,36 @@
 <template>
 <div>
 
-        <six-select placeholder="Select one">
-          <six-menu-label>Group 1</six-menu-label>
-          <six-menu-item value="option-1">Option 1</six-menu-item>
-          <six-menu-item value="option-2">Option 2</six-menu-item>
-          <six-menu-item value="option-3">Option 3</six-menu-item>
-          <six-menu-divider></six-menu-divider>
-          <six-menu-label>Group 2</six-menu-label>
-          <six-menu-item value="option-4">Option 4</six-menu-item>
-          <six-menu-item value="option-5">Option 5</six-menu-item>
-          <six-menu-item value="option-6">Option 6</six-menu-item>
+        <six-select filter placeholder="Select a few" multiple clearable>
+          <six-menu-item value="option-1"
+            >Option 1
+            <six-icon-button               size="small"
+              slot="suffix"
+              target="_blank"
+              href="#"
+              name="favorite"
+              onclick="event.stopPropagation()"
+            ></six-icon-button>
+          </six-menu-item>
+          <six-menu-item value="option-2"
+            >Option 2
+            <six-icon-button               size="small"
+              slot="suffix"
+              target="_blank"
+              href="#"
+              name="favorite"
+              onclick="event.stopPropagation()"
+            ></six-icon-button></six-menu-item>
+          <six-menu-item value="option-3"
+            >Option 3
+            <six-icon-button               size="small"
+              slot="suffix"
+              target="_blank"
+              href="#"
+              name="favorite"
+              onclick="event.stopPropagation()"
+            ></six-icon-button>
+          </six-menu-item>
         </six-select>
       
 </div>

--- a/libraries/ui-library/src/components/six-select/index.html
+++ b/libraries/ui-library/src/components/six-select/index.html
@@ -117,7 +117,56 @@
           <six-menu-item value="option-3">Option 3</six-menu-item>
           <six-menu-item value="option-4">Option 4</six-menu-item>
           <six-menu-item value="option-5">Option 5</six-menu-item>
-          <six-menu-item value="option-6">Option 6 (with tooltip due to long text)</six-menu-item>
+          <six-menu-item value="option-6">Option 6 (with tooltip due to long long long long text)</six-menu-item>
+        </six-select>
+      </section>
+
+      <h3>Multiple with Links</h3>
+      <p>
+        With the prefix and suffix slots you can add links to the menu items. This is useful for adding actions to the
+        menu items.
+      </p>
+      <style>
+        .demo-multiple-icons six-menu-item::part(base) {
+          display: flex;
+          align-items: center;
+        }
+      </style>
+      <section class="demo demo-multiple-icons" style="width: 300px">
+        <six-select filter placeholder="Select a few" multiple clearable>
+          <six-menu-item value="option-1"
+            >Option 1
+            <six-icon-button
+              size="small"
+              slot="suffix"
+              target="_blank"
+              href="#"
+              name="favorite"
+              onclick="event.stopPropagation()"
+            ></six-icon-button>
+          </six-menu-item>
+          <six-menu-item value="option-2"
+            >Option 2
+            <six-icon-button
+              size="small"
+              slot="suffix"
+              target="_blank"
+              href="#"
+              name="favorite"
+              onclick="event.stopPropagation()"
+            ></six-icon-button
+          ></six-menu-item>
+          <six-menu-item value="option-3"
+            >Option 3
+            <six-icon-button
+              size="small"
+              slot="suffix"
+              target="_blank"
+              href="#"
+              name="favorite"
+              onclick="event.stopPropagation()"
+            ></six-icon-button>
+          </six-menu-item>
         </six-select>
       </section>
 

--- a/libraries/ui-library/src/components/six-select/six-select.tsx
+++ b/libraries/ui-library/src/components/six-select/six-select.tsx
@@ -1,5 +1,5 @@
 import { Component, Element, Event, EventEmitter, h, Method, Prop, State, Watch } from '@stencil/core';
-import { getTextContent, hasSlot } from '../../utils/slot';
+import { getSlot, getTextContent, hasSlot } from '../../utils/slot';
 import FormControl from '../../functional-components/form-control/form-control';
 import { EmptyPayload } from '../../utils/types';
 import { EventListeners } from '../../utils/event-listeners';
@@ -268,6 +268,19 @@ export class SixSelect {
     }
   }
 
+  private getSlottedItem(item: HTMLSixMenuItemElement, slotName: 'prefix' | 'suffix') {
+    const slottedElement = getSlot(item, slotName);
+    if (slottedElement == null) {
+      return null;
+    }
+    const attributes = Object.fromEntries([...slottedElement.attributes].map((attr) => [attr.name, attr.value]));
+
+    return h(slottedElement.tagName.toLowerCase(), {
+      ...attributes,
+      innerHTML: slottedElement.innerHTML,
+    });
+  }
+
   private getItems(): HTMLSixMenuItemElement[] {
     if (this.options !== null && this.menu != null && this.menu.shadowRoot != null) {
       return [...this.menu.shadowRoot.querySelectorAll('six-menu-item')];
@@ -442,7 +455,9 @@ export class SixSelect {
               }
             }}
           >
+            {this.getSlottedItem(item, 'prefix')}
             {this.getItemLabel(item)}
+            {this.getSlottedItem(item, 'suffix')}
           </six-menu-item>
         );
       });


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/six-group/six-webcomponents/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In the six-select component it was not possible to use the suffix and prefix slot of the six-menu-items as this produced bugs. This is now fixed and the prefix and suffix slots can be used, which makes it possible to have six-icons links in the menu-items. 



