### PR TITLE
docs: add navigation to jump to v4 docs

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -37,6 +37,7 @@ export default withMermaid({
       },
       { text: 'Components', link: componentNavItems[0].link },
       { text: 'Changelog', link: '/changelog' },
+      { text: 'Go to v4 docs', link: 'https://six-group.github.io/six-webcomponents/v4/' },
     ],
 
     sidebar: {

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -45,10 +45,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Removed
 
 - **⚠️Breaking**: Removed most slots, properties and events on the `six-header` component. Replaced
-  with a flexible approach for customization, allowing the header to be composed in a modular way
-  using child elements such as `six-header-item`, `six-header-dropdown-item`,
-  `six-header-menu-button`, and `six-logo`. Check the [upgrade guide](guide/upgrade-v5.md) for
-  detailed instructions.
+  with a flexible approach for customization, allowing the header to be composed modularly using
+  child elements such as `six-header-item`, `six-header-dropdown-item`, `six-header-menu-button`,
+  and `six-logo`. Check the [upgrade guide](guide/upgrade-v5.md) for detailed instructions.
 - **⚠️Breaking**: Removed the previously deprecated `reposition()` method of the `six-dropdown`
   component. You can use the `matchTriggerWidth` property instead.
 - **⚠️Breaking**: Removed the previously deprecated tag `maxTagsVisible` of the `six-select`
@@ -68,9 +67,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **⚠️Breaking**: `six-dialog`: replaced the `six-dialog-overlay-dismiss` event with
   `six-dialog-request-close`, which allows preventing the dialog from closing not only when clicking
   the overlay but also when clicking the close button or pressing `Escape`.
-- Upgraded Stencil to latest release and upgraded Vue output target
-- Upgraded React output target to version 1.0.0
-- Upgraded Angular output target to version 0.10.2
 - Upgraded Angular Demo App to version 20. Rewritten with
   [standalone bootstrapping](https://angular.dev/reference/migrations/standalone#switch-to-standalone-bootstrapping-api),
   signals, new template syntax, etc.


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/six-group/six-webcomponents/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Top-Level Navigation of v5 docs now contains a link to the v4 docs. (Same will be added to the v4 docs in time)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] It's submitted to the `main` branch
- [ ] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [ ] I have updated the documentation accordingly.
- [ ] All tests are passing
- [ ] New/updated tests are included
- [ ] I have updated the "upcoming" section inside _docs/changelog.md_ explaining the changes I contributed

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)

**Other information:**
