### PR TITLE
chore: deprecate `six-datepicker` in favor of `six-date`

### DIFF
--- a/docs/components/six-date.md
+++ b/docs/components/six-date.md
@@ -23,7 +23,16 @@ Use the `value` attribute to set the date date's value.
 <docs-demo-six-date-1></docs-demo-six-date-1>
 
 ```html
-<six-date label="Date with initial value" value="2025-01-15"></six-date>
+<six-button type="secondary" id="set-value-button">Set Value</six-button>
+<six-date id="set-value-date" label="Date with initial value" value="2025-01-15"></six-date>
+
+<script type="module">
+  (() => {
+    const openButton = document.getElementById('set-value-button');
+    const dateComponent = document.getElementById('set-value-date');
+    openButton.addEventListener('click', () => (dateComponent.value = '2030-01-01'));
+  })();
+</script>
 ```
 
 

--- a/docs/components/six-datepicker.md
+++ b/docs/components/six-datepicker.md
@@ -1,5 +1,9 @@
 # Datepicker
 
+::: warning
+The six-datepicker component is deprecated. Please use the [six-date](./six-date.md) component instead.
+:::
+
 
 Datepickers allow the user to manually enter a date or open a popup calendar to select a date.
 

--- a/docs/examples/docs-demo-six-date-1.vue
+++ b/docs/examples/docs-demo-six-date-1.vue
@@ -1,7 +1,10 @@
 <template>
 <div>
 
-        <six-date label="Date with initial value" value="2025-01-15"></six-date>
+        <six-button type="secondary" id="set-value-button">Set Value</six-button>
+        <six-date id="set-value-date" label="Date with initial value" value="2025-01-15"></six-date>
+
+        
       
 </div>
 </template>
@@ -11,6 +14,12 @@
 <script>
 export default {
   name: 'docs-demo-six-date-1',
-  mounted() {  }
+  mounted() { 
+          (() => {
+            const openButton = document.getElementById('set-value-button');
+            const dateComponent = document.getElementById('set-value-date');
+            openButton.addEventListener('click', () => (dateComponent.value = '2030-01-01'));
+          })();
+         }
 }
 </script>

--- a/libraries/ui-library/src/components.d.ts
+++ b/libraries/ui-library/src/components.d.ts
@@ -399,7 +399,7 @@ export namespace Components {
     }
     /**
      * @since 1.0
-     * @status stable
+     * @status deprecated. Use six-date instead.
      */
     interface SixDatepicker {
         /**
@@ -2781,7 +2781,7 @@ declare global {
     }
     /**
      * @since 1.0
-     * @status stable
+     * @status deprecated. Use six-date instead.
      */
     interface HTMLSixDatepickerElement extends Components.SixDatepicker, HTMLStencilElement {
         addEventListener<K extends keyof HTMLSixDatepickerElementEventMap>(type: K, listener: (this: HTMLSixDatepickerElement, ev: SixDatepickerCustomEvent<HTMLSixDatepickerElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -4038,7 +4038,7 @@ declare namespace LocalJSX {
     }
     /**
      * @since 1.0
-     * @status stable
+     * @status deprecated. Use six-date instead.
      */
     interface SixDatepicker {
         /**
@@ -6404,7 +6404,7 @@ declare module "@stencil/core" {
             "six-date": LocalJSX.SixDate & JSXBase.HTMLAttributes<HTMLSixDateElement>;
             /**
              * @since 1.0
-             * @status stable
+             * @status deprecated. Use six-date instead.
              */
             "six-datepicker": LocalJSX.SixDatepicker & JSXBase.HTMLAttributes<HTMLSixDatepickerElement>;
             /**

--- a/libraries/ui-library/src/components/six-date/index.html
+++ b/libraries/ui-library/src/components/six-date/index.html
@@ -23,7 +23,16 @@
       <h2>Setting a Value</h2>
       <p>Use the <code>value</code> attribute to set the date date's value.</p>
       <section>
-        <six-date label="Date with initial value" value="2025-01-15"></six-date>
+        <six-button type="secondary" id="set-value-button">Set Value</six-button>
+        <six-date id="set-value-date" label="Date with initial value" value="2025-01-15"></six-date>
+
+        <script type="module">
+          (() => {
+            const openButton = document.getElementById('set-value-button');
+            const dateComponent = document.getElementById('set-value-date');
+            openButton.addEventListener('click', () => (dateComponent.value = '2030-01-01'));
+          })();
+        </script>
       </section>
 
       <!-- Date Constraints -->

--- a/libraries/ui-library/src/components/six-date/iso-date.spec.ts
+++ b/libraries/ui-library/src/components/six-date/iso-date.spec.ts
@@ -4,6 +4,7 @@ import {
   getMonth,
   IsoDate,
   isValidIsoDate,
+  nextPointerDate,
   today,
   todayAsPointerDate,
   toPointerDate,
@@ -109,6 +110,55 @@ describe('iso-date', () => {
     test('demonstrates why using toISOString() is incorrect', () => {
       expect(new Date().toISOString().substring(0, 10)).toBe('2021-12-31');
     });
+  });
+
+  describe('nextPointerDate', () => {
+    const nextPointerDateCases = [
+      {
+        selectionMode: 'day' as const,
+        pointerDate: { year: 2022, month: 6, day: 15 },
+        expected: { year: 2022, month: 7, day: 1 },
+      },
+      {
+        selectionMode: 'day' as const,
+        pointerDate: { year: 2022, month: 12, day: 31 },
+        expected: { year: 2023, month: 1, day: 1 },
+      },
+      {
+        selectionMode: 'day' as const,
+        pointerDate: { year: 2022, month: 1, day: 1 },
+        expected: { year: 2022, month: 2, day: 1 },
+      },
+
+      {
+        selectionMode: 'month' as const,
+        pointerDate: { year: 2022, month: 6, day: 15 },
+        expected: { year: 2023, month: 6, day: 15 },
+      },
+      {
+        selectionMode: 'month' as const,
+        pointerDate: { year: 2021, month: 12, day: 31 },
+        expected: { year: 2022, month: 12, day: 31 },
+      },
+
+      {
+        selectionMode: 'year' as const,
+        pointerDate: { year: 2022, month: 6, day: 15 },
+        expected: { year: 2047, month: 6, day: 15 },
+      },
+      {
+        selectionMode: 'year' as const,
+        pointerDate: { year: 2000, month: 1, day: 1 },
+        expected: { year: 2025, month: 1, day: 1 },
+      },
+    ];
+
+    test.each(nextPointerDateCases)(
+      'calculates next pointer date for selectionMode `$selectionMode` and pointerDate $pointerDate, expects $expected',
+      ({ selectionMode, pointerDate, expected }) => {
+        expect(nextPointerDate(selectionMode, pointerDate)).toEqual(expected);
+      }
+    );
   });
 
   describe('isValidIsoDate', () => {

--- a/libraries/ui-library/src/components/six-date/iso-date.ts
+++ b/libraries/ui-library/src/components/six-date/iso-date.ts
@@ -81,12 +81,41 @@ export function toPointerDate(isoDate: IsoDate): PointerDate {
   if (!isValidIsoDate(isoDate)) {
     throw new Error(`Invalid ISO date: ${isoDate}`);
   }
-
   return {
     year: parseInt(isoDate.slice(0, 4), 10),
     month: parseInt(isoDate.slice(5, 7), 10),
     day: parseInt(isoDate.slice(8), 10),
   };
+}
+
+export function nextPointerDate(selectionMode: 'day' | 'month' | 'year', pointerDate: PointerDate): PointerDate {
+  if (selectionMode === 'day') {
+    if (pointerDate.month === 12) {
+      return { year: pointerDate.year + 1, month: 1, day: 1 };
+    } else {
+      return { year: pointerDate.year, month: pointerDate.month + 1, day: 1 };
+    }
+  } else if (selectionMode === 'month') {
+    return { ...pointerDate, year: pointerDate.year + 1 };
+  } else if (selectionMode === 'year') {
+    return { ...pointerDate, year: pointerDate.year + 25 };
+  }
+  return pointerDate;
+}
+
+export function previousPointerDate(selectionMode: 'day' | 'month' | 'year', pointerDate: PointerDate): PointerDate {
+  switch (selectionMode) {
+    case 'day':
+      if (pointerDate.month === 1) {
+        return { year: pointerDate.year - 1, month: 12, day: 1 };
+      } else {
+        return { year: pointerDate.year, month: pointerDate.month - 1, day: 1 };
+      }
+    case 'month':
+      return { ...pointerDate, year: pointerDate.year - 1 };
+    case 'year':
+      return { ...pointerDate, year: pointerDate.year - 25 };
+  }
 }
 
 export function todayAsPointerDate(): PointerDate {

--- a/libraries/ui-library/src/components/six-date/six-date.tsx
+++ b/libraries/ui-library/src/components/six-date/six-date.tsx
@@ -5,7 +5,15 @@ import { MonthSelection } from './components/month-selection';
 import { YearSelection } from './components/year-selection';
 import { DaySelection } from './components/day-selection';
 import { Language } from '../../utils/error-messages';
-import { cleanupValue, formatDate, fromFormattedString, todayAsPointerDate, toPointerDate } from './iso-date';
+import {
+  cleanupValue,
+  formatDate,
+  fromFormattedString,
+  nextPointerDate,
+  previousPointerDate,
+  todayAsPointerDate,
+  toPointerDate,
+} from './iso-date';
 import { createCalendarGrid } from './calendar-grid';
 import { translateFormatHelp, translateMonth } from './translations';
 import Popover from '../../utils/popover';
@@ -177,6 +185,7 @@ export class SixDate {
     if (warning != null) {
       console.warn(warning);
     }
+    this.updateInputElementValue();
   }
 
   private getSixInputBaseElement() {
@@ -220,35 +229,11 @@ export class SixDate {
   }
 
   private handlePreviousClick = () => {
-    switch (this.selectionMode) {
-      case 'day':
-        if (this.pointerDate.month === 0) {
-          this.pointerDate = { year: this.pointerDate.year - 1, month: 11, day: 1 };
-        } else {
-          this.pointerDate = { year: this.pointerDate.year, month: this.pointerDate.month - 1, day: 1 };
-        }
-        break;
-      case 'month':
-        this.pointerDate = { ...this.pointerDate, year: this.pointerDate.year - 1 };
-        break;
-      case 'year':
-        this.pointerDate = { ...this.pointerDate, year: this.pointerDate.year - NUMBER_OF_YEARS_SHOWN };
-        break;
-    }
+    this.pointerDate = previousPointerDate(this.selectionMode, this.pointerDate);
   };
 
   private handleNextClick = () => {
-    if (this.selectionMode === 'day') {
-      if (this.pointerDate.month === 11) {
-        this.pointerDate = { year: this.pointerDate.year + 1, month: 0, day: 1 };
-      } else {
-        this.pointerDate = { year: this.pointerDate.year, month: this.pointerDate.month + 1, day: 1 };
-      }
-    } else if (this.selectionMode === 'month') {
-      this.pointerDate = { ...this.pointerDate, year: this.pointerDate.year + 1 };
-    } else if (this.selectionMode === 'year') {
-      this.pointerDate = { ...this.pointerDate, year: this.pointerDate.year + NUMBER_OF_YEARS_SHOWN };
-    }
+    this.pointerDate = nextPointerDate(this.selectionMode, this.pointerDate);
   };
 
   private handleDocumentMouseDown = (event: Event) => {
@@ -321,7 +306,7 @@ export class SixDate {
   };
 
   private updateInputElementValue() {
-    if (this.inputElement) {
+    if (this.inputElement && document.activeElement !== this.host) {
       this.inputElement.value = this.value === '' ? '' : formatDate(this.value, this.dateFormat);
     }
   }

--- a/libraries/ui-library/src/components/six-datepicker/readme.md
+++ b/libraries/ui-library/src/components/six-datepicker/readme.md
@@ -1,5 +1,9 @@
 # six-datepicker
 
+::: warning
+The six-datepicker component is deprecated. Please use the [six-date](./six-date.md) component instead.
+:::
+
 <!-- EXAMPLES -->
 
 <!-- Auto Generated Below -->

--- a/libraries/ui-library/src/components/six-datepicker/six-datepicker.tsx
+++ b/libraries/ui-library/src/components/six-datepicker/six-datepicker.tsx
@@ -59,7 +59,7 @@ enum SelectionMode {
 
 /**
  * @since 1.0
- * @status stable
+ * @status deprecated. Use six-date instead.
  *
  * @slot - Used to define a footer for the date picker.
  * @slot error-text - Error text that is shown for validation errors. Alternatively, you can use the error-text prop.


### PR DESCRIPTION
Deprecate `six-datepicker` in favor of `six-date`, fix edit with keyboard and next/previous navigation
