### PR TITLE
poc e2e tests using playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,20 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm ci
       - run: npm run test
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+      - name: Run E2E tests
+        run: npm run test:e2e
       - run: npm run build
       - run: npm run prettier:check
       - run: npm run lint:lib
       - name: verify clean build
         run: git diff --exit-code
+
+        # Upload Playwright report on failure
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: ./libraries/ui-library/playwright-report/
+          retention-days: 30

--- a/.idea/runConfigurations/All_Tests_in_playwright_config_ts.xml
+++ b/.idea/runConfigurations/All_Tests_in_playwright_config_ts.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="All Tests in playwright.config.ts" type="JavaScriptTestRunnerPlaywright" nameIsGenerated="true">
+    <config value="$PROJECT_DIR$/libraries/ui-library/playwright.config.ts" />
+    <node-interpreter value="project" />
+    <playwright-package value="$PROJECT_DIR$/node_modules/@playwright/test" />
+    <working-dir value="$PROJECT_DIR$/libraries/ui-library" />
+    <envs />
+    <scope-kind value="ALL" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.prettierignore
+++ b/.prettierignore
@@ -17,3 +17,5 @@ docs/examples
 docs/components
 docs/.vitepress/cache
 .next
+playwright-report/
+test-results/

--- a/docs/guide/readme.md
+++ b/docs/guide/readme.md
@@ -67,3 +67,14 @@ npm run demo:angular
 
 The demo app at http://localhost:4200 automatically update whenever changes are made to the
 ui-library, the Angular library, or the demo code.
+
+### Playwright - E2E Tests
+
+Run the following to install playwright webdrivers:
+
+```bash
+run npx playwright
+```
+
+For iIntelliJ IDEA it is recommended to install the Test Automation plugin, which helps develop and
+maintain automated UI tests.

--- a/libraries/ui-library/.gitignore
+++ b/libraries/ui-library/.gitignore
@@ -3,6 +3,8 @@ www/
 loader/
 docs/
 coverage/
+playwright-report/
+test-results/
 
 *~
 *.sw[mnpcod]

--- a/libraries/ui-library/.prettierignore
+++ b/libraries/ui-library/.prettierignore
@@ -1,1 +1,3 @@
 src/components.d.ts
+playwright-report/
+test-results/

--- a/libraries/ui-library/jest.config.js
+++ b/libraries/ui-library/jest.config.js
@@ -1,3 +1,5 @@
 module.exports = {
   preset: '@stencil/core/testing',
+  testMatch: ['**/*.spec.ts', '**/*.spec.tsx'],
+  testPathIgnorePatterns: ['\\.e2e\\.ts$'],
 };

--- a/libraries/ui-library/package.json
+++ b/libraries/ui-library/package.json
@@ -26,6 +26,9 @@
     "test:allInclCoverage": "stencil test --spec --e2e --coverage",
     "test:debug": "stencil test --spec --e2e --devtools",
     "test.watch": "stencil test --spec --e2e --watchAll",
+    "test:e2e": "playwright test",
+    "test:e2eDebug": "playwright test --debug --headed",
+    "test:e2eUi": "playwright test --ui",
     "generate": "stencil generate",
     "clean": "rimraf dist loader www docs",
     "lint": "    eslint       src/**/*{.ts,.tsx}",
@@ -40,6 +43,8 @@
     "date-fns": ">=3.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.56.1",
+    "@stencil/playwright": "^0.2.1",
     "@fontsource/material-icons": "^5.1.1",
     "@fontsource/material-icons-outlined": "^5.1.1",
     "@fontsource-variable/material-symbols-outlined": "^5.2.22",
@@ -55,6 +60,7 @@
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "cross-env": "^7.0.3",
+    "puppeteer": "^20.9.0",
     "replace-in-file": "^6.3.5",
     "rimraf": "^3.0.2"
   },

--- a/libraries/ui-library/playwright.config.ts
+++ b/libraries/ui-library/playwright.config.ts
@@ -1,0 +1,23 @@
+import { expect } from '@playwright/test';
+import { matchers, createConfig } from '@stencil/playwright';
+
+// Add custom Stencil matchers to Playwright assertions
+expect.extend(matchers);
+
+export default createConfig({
+  testDir: './src',
+  testMatch: '**/*.e2e.ts',
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3333',
+    screenshot: 'only-on-failure',
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+  },
+
+  webServer: {
+    command: 'npm run start',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+  },
+});

--- a/libraries/ui-library/src/components/six-button/test/six-button.e2e.ts
+++ b/libraries/ui-library/src/components/six-button/test/six-button.e2e.ts
@@ -1,0 +1,69 @@
+import { test } from '@stencil/playwright';
+import { expect } from '@playwright/test';
+
+declare global {
+  interface Window {
+    buttonClicked?: boolean;
+  }
+}
+
+test.describe('six-button', () => {
+  test('should render as an anchor element when href is set', async ({ page }) => {
+    await page.setContent('<six-button href="https://example.com">Link</six-button>');
+    await expect(page.getByRole('link')).toBeVisible();
+  });
+
+  test('should be clickable by default', async ({ page }) => {
+    await page.setContent('<six-button>Click Me</six-button>');
+    await page.getByRole('button').click();
+  });
+
+  test('should show spinner and not clickable', async ({ page }) => {
+    await page.setContent('<six-button loading>Loading</six-button>');
+    await expect(page.locator('six-button six-spinner')).toBeVisible();
+
+    await page.evaluate(() => {
+      const btn = document.querySelector('six-button');
+      btn?.addEventListener('click', () => {
+        window.buttonClicked = true;
+      });
+    });
+
+    await page.getByRole('button').click({ force: true });
+
+    // the button should not be clicked
+    const wasClicked = await page.evaluate(() => window.buttonClicked === true);
+    expect(wasClicked).toBe(false);
+  });
+
+  test('should render with caret', async ({ page }) => {
+    await page.setContent('<six-button caret>Dropdown</six-button>');
+    const button = page.getByRole('button');
+    await expect(button.locator('svg')).toBeVisible();
+  });
+
+  test('should render both prefix and suffix slots', async ({ page }) => {
+    await page.setContent(`
+        <six-button>
+          <span slot="prefix">←</span>
+          Back
+         <span slot="suffix">→</span>
+        </six-button>
+      `);
+    await page.getByText('←').click();
+    await page.getByText('→').click();
+  });
+
+  test('should handle focus correctly', async ({ page }) => {
+    await page.setContent(`
+        <six-button data-testid="btn1">Button 1</six-button>
+        <six-button data-testid="btn2">Button 2</six-button>
+      `);
+
+    await page.getByTestId('btn1').click();
+    await expect(page.getByTestId('btn1')).toBeFocused();
+
+    await page.getByTestId('btn2').click();
+    await expect(page.getByTestId('btn1')).not.toBeFocused();
+  });
+});

--- a/libraries/ui-library/stencil.config.ts
+++ b/libraries/ui-library/stencil.config.ts
@@ -127,6 +127,7 @@ export const config: Config = {
         },
 
         { src: '**/*.html' },
+        { src: '**/*.scss' },
       ],
     },
   ],

--- a/libraries/ui-library/tsconfig.json
+++ b/libraries/ui-library/tsconfig.json
@@ -3,7 +3,7 @@
     "allowSyntheticDefaultImports": true,
     "allowUnreachableCode": false,
     "experimentalDecorators": true,
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": ["dom", "dom.iterable", "esnext", "ESNext.Disposable"],
     "moduleResolution": "node",
     "module": "esnext",
     "target": "es2017",

--- a/package-lock.json
+++ b/package-lock.json
@@ -670,15 +670,18 @@
         "@fontsource/material-icons": "^5.1.1",
         "@fontsource/material-icons-outlined": "^5.1.1",
         "@fontsource/noto-sans": "^5.1.1",
+        "@playwright/test": "^1.56.1",
         "@popperjs/core": "^2.5.3",
         "@stencil-community/eslint-plugin": "0.x",
         "@stencil/angular-output-target": "1.0.0",
+        "@stencil/playwright": "^0.2.1",
         "@stencil/react-output-target": "^1.0.4",
         "@stencil/sass": "3.0.12",
         "@stencil/vue-output-target": "0.10.8",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
         "cross-env": "^7.0.3",
+        "puppeteer": "^20.9.0",
         "replace-in-file": "^6.3.5",
         "rimraf": "^3.0.2"
       },
@@ -11205,6 +11208,22 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
+      "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.56.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
@@ -12095,6 +12114,127 @@
         "@rollup/rollup-linux-x64-musl": "4.34.9",
         "@rollup/rollup-win32-arm64-msvc": "4.34.9",
         "@rollup/rollup-win32-x64-msvc": "4.34.9"
+      }
+    },
+    "node_modules/@stencil/playwright": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@stencil/playwright/-/playwright-0.2.1.tgz",
+      "integrity": "sha512-SMZpS7OGV3IfCie49Lcb31VexsgXxuPUS19r+T20Ru1t2ahhGBmsRYnYYZEFwlDFO9+6R8gqpomZ+obSB7A1KQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.3.1",
+        "find-up": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0",
+        "npm": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "@playwright/test": ">=1.41.2",
+        "@stencil/core": ">=4.13.0"
+      }
+    },
+    "node_modules/@stencil/playwright/node_modules/find-up": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-7.0.0.tgz",
+      "integrity": "sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^7.2.0",
+        "path-exists": "^5.0.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stencil/playwright/node_modules/locate-path": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stencil/playwright/node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stencil/playwright/node_modules/p-locate": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stencil/playwright/node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/@stencil/playwright/node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@stencil/playwright/node_modules/yocto-queue": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@stencil/react-output-target": {
@@ -19128,7 +19268,6 @@
       "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-fetch": "^2.6.12"
       }
@@ -19139,7 +19278,6 @@
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -19160,16 +19298,14 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/cross-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/cross-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -19177,7 +19313,6 @@
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -28377,8 +28512,7 @@
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/mlly": {
       "version": "1.7.4",
@@ -31298,6 +31432,53 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
     },
+    "node_modules/playwright": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
+      "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.56.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
+      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/points-on-curve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
@@ -32359,6 +32540,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/puppeteer": {
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-20.9.0.tgz",
+      "integrity": "sha512-kAglT4VZ9fWEGg3oLc4/de+JcONuEJhlh3J6f5R1TLkrY/EHHIHxWXDOzXvaxQCtedmyVXBwg8M+P8YCO/wZjw==",
+      "deprecated": "< 24.15.0 is no longer supported",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "1.4.6",
+        "cosmiconfig": "8.2.0",
+        "puppeteer-core": "20.9.0"
+      },
+      "engines": {
+        "node": ">=16.3.0"
+      }
+    },
     "node_modules/puppeteer-core": {
       "version": "21.11.0",
       "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-21.11.0.tgz",
@@ -32502,6 +32700,268 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/puppeteer/node_modules/@puppeteer/browsers": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.4.6.tgz",
+      "integrity": "sha512-x4BEjr2SjOPowNeiguzjozQbsc6h437ovD/wu+JpaenxVLm3jkgzHY2xOslMTp50HoTvQreMjiexiGQw1sqZlQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "4.3.4",
+        "extract-zip": "2.0.1",
+        "progress": "2.0.3",
+        "proxy-agent": "6.3.0",
+        "tar-fs": "3.0.4",
+        "unbzip2-stream": "1.4.3",
+        "yargs": "17.7.1"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=16.3.0"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.7.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer/node_modules/chromium-bidi": {
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.16.tgz",
+      "integrity": "sha512-7ZbXdWERxRxSwo3txsBjjmc/NLxqb1Bk30mRb0BMS4YIaiV6zvKZqL/UAH+DdqcDYayDWk2n/y8klkBDODrPvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "3.0.0"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
+      }
+    },
+    "node_modules/puppeteer/node_modules/cosmiconfig": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
+      "integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/d-fischer"
+      }
+    },
+    "node_modules/puppeteer/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer/node_modules/devtools-protocol": {
+      "version": "0.0.1147663",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1147663.tgz",
+      "integrity": "sha512-hyWmRrexdhbZ1tcJUGpO95ivbRhWXz++F4Ko+n21AY5PNln2ovoJw+8ZMNDTtip+CNFQfrtLVh/w4009dXO/eQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/puppeteer/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/puppeteer/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/puppeteer/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/puppeteer/node_modules/mitt": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
+      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/puppeteer/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/puppeteer/node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/puppeteer/node_modules/proxy-agent": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.0.tgz",
+      "integrity": "sha512-0LdR757eTj/JfuU7TL2YCuAZnxWXu3tkJbg4Oq3geW/qFNT/32T0sp2HnZ9O0lMR4q3vwAt0+xCA8SR0WAD0og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.0.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/puppeteer/node_modules/puppeteer-core": {
+      "version": "20.9.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.9.0.tgz",
+      "integrity": "sha512-H9fYZQzMTRrkboEfPmf7m3CLDN6JvbxXA3qTtS+dFt27tR+CsFHzPsT6pzp6lYL6bJbAPaR0HaPO6uSi+F94Pg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "1.4.6",
+        "chromium-bidi": "0.4.16",
+        "cross-fetch": "4.0.0",
+        "debug": "4.3.4",
+        "devtools-protocol": "0.0.1147663",
+        "ws": "8.13.0"
+      },
+      "engines": {
+        "node": ">=16.3.0"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.7.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/puppeteer/node_modules/tar-fs": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
+      "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      }
+    },
+    "node_modules/puppeteer/node_modules/ws": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/puppeteer/node_modules/yargs": {
+      "version": "17.7.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/puppeteer/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/pure-rand": {
@@ -36203,8 +36663,7 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/thunky": {
       "version": "1.1.0",
@@ -36734,7 +37193,6 @@
       "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
@@ -36760,7 +37218,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build:lib": "npm run build -w libraries",
     "lint:lib": "npm run lint -w libraries --if-present",
     "test": "npm run test -w libraries/ui-library",
+    "test:e2e": "npm run test:e2e -w libraries/ui-library",
     "demo:angular": "npm start -w examples/angular",
     "demo:vue": "npm run dev -w examples/vue",
     "demo:react": "npm run dev -w examples/react",


### PR DESCRIPTION
# 💡 Playwright E2E Testing POC

This PR introduces a proof of concept for using the  [Stencil Playwright adapter](https://stenciljs.com/docs/testing/playwright/overview)  to run end-to-end (E2E) tests on our web components.

## 🧪 Overview

The goal of this POC is to evaluate the experimental @stencil/playwright adapter and determine whether it’s a good fit for our component library’s testing workflow.
Playwright provides cross-browser automation using real browser engines, making it a strong candidate for reliable UI testing in CI.

## ⚙️ Implementation Details

- Integrated the Stencil Playwright adapter (requires Stencil v4.13.0+).

- Created an example e2e testfile for six-button: six-button.e2e.ts.

- Used the page.setContent() approach to define test HTML inline:

`await page.setContent('<six-button>Click Me</six-button>').click();`

- This pattern enables isolated testing per component, without modifying shared HTML templates or relying on page.goto().

## 🧩 Benefits of This Approach

- Isolated component tests — each test defines its own HTML.

- Lightweight and CI-friendly — HTML reports are generated and uploaded as CI artifacts on test failure for easy debugging. To view the full trace-report you have to download the generated playwright-report.zip and run:

`npx playwright show-report path-to-extracted-zip/playwright-report`

## 🚧 Notes

- The @stencil/playwright adapter is experimental, so breaking changes are possible.

- This PR is meant purely as a POC to explore feasibility and developer experience before full adoption.
