### PR TITLE
chore: update github release and coverage actions and remove deprecated ones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,18 @@ jobs:
           retention-days: 30
 
       - name: code coverage report
-        uses: 5monkeys/cobertura-action@master
-        if: github.event_name == 'pull_request' && !cancelled()
+        uses: actions/upload-code-coverage@v1
         with:
-          path: libraries/ui-library/coverage/cobertura-coverage.xml
-          minimum_coverage: 0
+          file: libraries/ui-library/coverage/cobertura-coverage.xml
+          language: Typescript
+          label: code-coverage/jacoco
+
+  #      - name: code coverage report
+  #        uses: 5monkeys/cobertura-action@master
+  #        if: github.event_name == 'pull_request' && !cancelled()
+  #        with:
+  #          path: libraries/ui-library/coverage/cobertura-coverage.xml
+  #          minimum_coverage: 0
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,6 @@ jobs:
 
   e2e-tests:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      code-quality: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -54,18 +51,11 @@ jobs:
           retention-days: 30
 
       - name: code coverage report
-        uses: actions/upload-code-coverage@v1
+        uses: colinscz/cobertura-action@master
+        if: github.event_name == 'pull_request' && !cancelled()
         with:
-          file: libraries/ui-library/coverage/cobertura-coverage.xml
-          language: Typescript
-          label: code-coverage/jacoco
-
-  #      - name: code coverage report
-  #        uses: 5monkeys/cobertura-action@master
-  #        if: github.event_name == 'pull_request' && !cancelled()
-  #        with:
-  #          path: libraries/ui-library/coverage/cobertura-coverage.xml
-  #          minimum_coverage: 0
+          path: libraries/ui-library/coverage/cobertura-coverage.xml
+          minimum_coverage: 0
 
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
 
   e2e-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      code-quality: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  pull-requests: write
+
 jobs:
   lint-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,9 @@ on:
       - main
 
 permissions:
+  contents: read
   pull-requests: write
+  checks: write
 
 jobs:
   lint-and-test:
@@ -54,7 +56,7 @@ jobs:
           retention-days: 30
 
       - name: code coverage report
-        uses: colinscz/cobertura-action@master
+        uses: colinscz/cobertura-action@v15
         if: github.event_name == 'pull_request' && !cancelled()
         with:
           path: libraries/ui-library/coverage/cobertura-coverage.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,13 +124,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Create GitHub release'
-        uses: actions/create-release@latest
+        uses: softprops/action-gh-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ inputs.version }}
-          release_name: '${{ inputs.version }}'
-          body: '${{ inputs.version }}'
+          name: '${{ inputs.version }}'
+          generate_release_notes: true
+          make_latest: true
 
       - name: 'Deploy Documentation'
         uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/six-group/six-webcomponents/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)

### 📚 Description

- Forked cobertura-action with Node 24 update
- Switched to new and supported Github release action

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://github.com/six-group/six-webcomponents/blob/dev/.github/CONTRIBUTING.md
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to the SIX Webcomponents!
----------------------------------------------------------------------->
