### PR TITLE
549 Fixed six-file-upload-success being emitted twice on file drop in Ang…

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Upcoming
 
+### Fixed
+
+- `six-file-upload`: Fixed six-file-upload-success being emitted twice on file drop in Angular
+  applications using Zone.js.
+
 ## 5.5.0 - 2026-07-03
 
 - `six-breadcrumbs` new style aligned with design guidelines. Added `size` interface property.

--- a/libraries/ui-library/src/components/six-file-upload/six-file-upload.tsx
+++ b/libraries/ui-library/src/components/six-file-upload/six-file-upload.tsx
@@ -68,28 +68,28 @@ export class SixFileUpload {
   /** Triggers when an uploaded file doesn't match MIME type or max file size. */
   @Event({ eventName: 'six-file-upload-failure' }) failure!: EventEmitter<SixFileUploadFailurePayload>;
 
-  @Listen('dragenter', { capture: false })
+  @Listen('dragenter', { capture: false, passive: false })
   dragenterHandler() {
     if (!this.disabled) {
       this.isOver = true;
     }
   }
 
-  @Listen('dragover', { capture: false })
+  @Listen('dragover', { capture: false, passive: false })
   dragoverHandler() {
     if (!this.disabled) {
       this.isOver = true;
     }
   }
 
-  @Listen('dragleave', { capture: false })
+  @Listen('dragleave', { capture: false, passive: false })
   dragleaveHandler() {
     if (!this.disabled) {
       this.isOver = false;
     }
   }
 
-  @Listen('drop', { capture: false })
+  @Listen('drop', { capture: false, passive: false })
   dropHandler(event: DragEvent) {
     if (!this.disabled) {
       this.isOver = false;
@@ -157,16 +157,16 @@ export class SixFileUpload {
 
   componentDidLoad() {
     ['dragenter', 'dragover', 'dragleave', 'drop'].forEach((eventName) => {
-      this.host.addEventListener(eventName, this.preventDefaults, false);
-      document.body.addEventListener(eventName, this.preventDefaults, false);
+      this.host.addEventListener(eventName, this.preventDefaults, { capture: false, passive: false });
+      document.body.addEventListener(eventName, this.preventDefaults, { capture: false, passive: false });
     });
     this.host.shadowRoot?.addEventListener('slotchange', this.handleSlotChange);
   }
 
   disconnectedCallback() {
     ['dragenter', 'dragover', 'dragleave', 'drop'].forEach((eventName) => {
-      this.host.removeEventListener(eventName, this.preventDefaults, false);
-      document.body.removeEventListener(eventName, this.preventDefaults, false);
+      this.host.removeEventListener(eventName, this.preventDefaults, { capture: false });
+      document.body.removeEventListener(eventName, this.preventDefaults, { capture: false });
     });
     this.host.shadowRoot?.removeEventListener('slotchange', this.handleSlotChange);
   }


### PR DESCRIPTION
…ular applications using Zone.js

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/six-group/six-webcomponents/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->

### 🔗 Linked issue

Resolves #549

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Zone.js ignored the preventDefault on the vent listener because it was not marked as passive. This caused errors in the console and six-file-upload-success being emitted twice.

