### PR TITLE
chore: ignore stencil output targets for auto update prs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,10 @@
   ],
   "ignoreDeps": [
     "node",
-    "npm"
+    "npm",
+    "@stencil/angular-output-target",
+    "@stencil/vue-output-target",
+    "@stencil/react-output-target"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/six-group/six-webcomponents/blob/dev/.github/CONTRIBUTING.md#pull-request-guidelines
-->

<!-- PULL REQUEST TEMPLATE -->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)

### 📚 Description
Remove stencil from autoupdates, since the bumps always require some additional changes.
